### PR TITLE
feat: bring back scripts folder from monorepo

### DIFF
--- a/scripts/vercel/ignore-build-step-base.sh
+++ b/scripts/vercel/ignore-build-step-base.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# This script is meant to be run from the "Ignored Build Step" in Vercel.
+
+npx turbo-ignore --fallback=HEAD^1

--- a/scripts/vercel/ignore-build-step-previews.sh
+++ b/scripts/vercel/ignore-build-step-previews.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script is meant to be run from the "Ignored Build Step" in Vercel.
+
+if [ "$VERCEL_ENV" == "preview" ]; then
+  echo "✅ - Preview environment detected. Checking for changes in apps..."
+  # Relative to the root directory of the project. E.g relative to apps/wallet-dashboard
+  bash ../../scripts/tooling/vercel/ignore-build-step-base.sh
+else
+  echo "❌ - Not a preview deployment."
+  exit 0
+fi

--- a/scripts/vercel/ignore-build-step-previews.sh
+++ b/scripts/vercel/ignore-build-step-previews.sh
@@ -4,7 +4,7 @@
 if [ "$VERCEL_ENV" == "preview" ]; then
   echo "✅ - Preview environment detected. Checking for changes in apps..."
   # Relative to the root directory of the project. E.g relative to apps/wallet-dashboard
-  bash ../../scripts/tooling/vercel/ignore-build-step-base.sh
+  bash ../../scripts/vercel/ignore-build-step-base.sh
 else
   echo "❌ - Not a preview deployment."
   exit 0


### PR DESCRIPTION
# Description of change

Brings back the scripts folder. It contains a sript needed in the vercel dashboard.
Updated path: (before) `scripts/tooling/vercel/**.sh` -> `scripts/vercel/*.sh`

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.
