### PR TITLE
chore(ci): add diagnostic logging to vercel ignore build step

### DIFF
--- a/scripts/vercel/ignore-build-step-base.sh
+++ b/scripts/vercel/ignore-build-step-base.sh
@@ -3,4 +3,15 @@
 
 PACKAGE_NAME="$(pnpm pkg get name | tr -d '"')"
 
+echo "--- git state ---"
+echo "HEAD:    $(git rev-parse HEAD 2>&1)"
+echo "HEAD^1:  $(git rev-parse HEAD^1 2>&1)"
+git log --oneline -5 2>&1 || true
+echo "--- changed files (HEAD^1..HEAD) ---"
+git diff --name-only HEAD^1 HEAD 2>&1 || true
+echo "--- .turbo state ---"
+ls -la ../../.turbo 2>/dev/null || echo "no root .turbo"
+ls -la .turbo 2>/dev/null || echo "no local .turbo"
+echo "--- turbo query ---"
+
 pnpx turbo query affected --packages "$PACKAGE_NAME" --base=HEAD^1 --exit-code

--- a/scripts/vercel/ignore-build-step-base.sh
+++ b/scripts/vercel/ignore-build-step-base.sh
@@ -14,4 +14,4 @@ ls -la ../../.turbo 2>/dev/null || echo "no root .turbo"
 ls -la .turbo 2>/dev/null || echo "no local .turbo"
 echo "--- turbo query ---"
 
-pnpx turbo query affected --packages "$PACKAGE_NAME" --base=HEAD^1 --exit-code
+pnpx turbo query affected --verbosity 2 --packages "$PACKAGE_NAME" --base=HEAD^1 --exit-code


### PR DESCRIPTION
## Context

The explorer deploy for commit [`243d43e`](https://github.com/iotaledger/ts-packages/commit/243d43e04a) on `develop` was canceled by the Ignored Build Step, despite the commit clearly touching `apps/explorer/**` and `apps/core/**`. The Vercel log showed:

```
✅ - Preview environment detected. Checking for changes in apps...
{
  "data": {
    "affectedPackages": {
      "items": [],
      "length": 0
    }
  }
}
The Deployment has been canceled as a result of running the command defined in the "Ignored Build Step" setting.
```

## Investigation so far

Ran the exact command locally against the same commit — could not reproduce:

- `git clone --depth=10 --branch develop` + `pnpx turbo query affected --packages iota-explorer --base=HEAD^1 --exit-code` → returns `length: 1`, exit 1 (would build). ✅
- Works both with and without `pnpm install`.
- Tested turbo `2.9.0`, `2.9.1`, `2.9.2`, `2.9.3`, `2.9.4`, `2.9.5`, `2.9.6` — all correctly detect `iota-explorer` as affected.

Remaining suspects, all Vercel-specific and not reproducible from here:

1. Restored `.turbo` cache from the previous deployment (log shows `Restored build cache from previous deployment (7Eia…)` immediately before the script runs).
2. Vercel's clone has [known quirks](https://github.com/vercel/vercel/discussions/9884) (no `origin/HEAD`, odd branch state) that could make `HEAD^1` resolve to something unexpected.
3. Some Vercel/turbo env var influencing the query.

## Change

Adds diagnostic logging to `scripts/vercel/ignore-build-step-base.sh` so the next canceled deploy shows:

- `HEAD` and `HEAD^1` SHAs
- recent commit log
- files changed between `HEAD^1..HEAD`
- any restored `.turbo/` state

With that output from a real Vercel run we can point at the actual cause instead of guessing. Once we know, the logging will be replaced with a targeted fix.