### PR TITLE
chore(vercel): Fix Ignore step script PACKAGE_NAME

### DIFF
--- a/apps/explorer/src/index.css
+++ b/apps/explorer/src/index.css
@@ -158,7 +158,3 @@ body,
         }
     }
 }
-
-.debug {
-    background-color: purple;
-}

--- a/scripts/vercel/ignore-build-step-base.sh
+++ b/scripts/vercel/ignore-build-step-base.sh
@@ -1,19 +1,12 @@
 #!/bin/bash
 # This script is meant to be run from the "Ignored Build Step" in Vercel.
 
-PACKAGE_NAME="$(pnpm pkg get name | tr -d '"')"
+PACKAGE_NAME="$(jq -r .name package.json)"
 
+echo "Package:       $PACKAGE_NAME"
+echo "HEAD:          $(git rev-parse HEAD)"
+echo "HEAD^1:        $(git rev-parse HEAD^1)"
+echo "Changed files:"
+git diff --name-only HEAD^1 HEAD | sed 's/^/  /'
 
-echo "--- git state ---"
-echo "HEAD:    $(git rev-parse HEAD 2>&1)"
-echo "HEAD^1:  $(git rev-parse HEAD^1 2>&1)"
-git log --oneline -5 2>&1 || true
-echo "--- changed files (HEAD^1..HEAD) ---"
-git diff --name-only HEAD^1 HEAD 2>&1 || true
-echo "--- .turbo state ---"
-ls -la ../../.turbo 2>/dev/null || echo "no root .turbo"
-ls -la .turbo 2>/dev/null || echo "no local .turbo"
-echo "--- turbo query ---"
-
-echo "Running Vercel Ignored Build Step for package: $PACKAGE_NAME, full command: pnpx turbo query affected --verbosity 2 --packages \"$PACKAGE_NAME\" --base=HEAD^1 --exit-code"
-pnpx turbo query affected --verbosity 2 --packages "$PACKAGE_NAME" --base=HEAD^1 --exit-code
+pnpx turbo query affected --packages "$PACKAGE_NAME" --base=HEAD^1 --exit-code


### PR DESCRIPTION
Fixes the 
```
pnpm pkg get name | tr -d '"'
```

resulting as `undefined` on vercel. 

Also revert a dummy commit.