### PR TITLE
feat(explorer): notarization simple page

### DIFF
--- a/apps/explorer/src/components/ui/PageHeader.tsx
+++ b/apps/explorer/src/components/ui/PageHeader.tsx
@@ -17,7 +17,14 @@ import { useCopyToClipboard } from '@iota/core';
 import clsx from 'clsx';
 import { type MetaItem, PageHeaderMeta } from './PageHeaderMeta';
 
-type PageHeaderType = 'Transaction' | 'Checkpoint' | 'Address' | 'Object' | 'Package' | 'Identity';
+type PageHeaderType =
+    | 'Transaction'
+    | 'Checkpoint'
+    | 'Address'
+    | 'Object'
+    | 'Package'
+    | 'Identity'
+    | 'Notarization';
 
 export interface PageHeaderProps {
     title: string | React.JSX.Element;

--- a/apps/explorer/src/hooks/useNotarizationState.ts
+++ b/apps/explorer/src/hooks/useNotarizationState.ts
@@ -3,7 +3,7 @@
 
 import { encodeB64 } from '@iota/identity-wasm/web';
 import type { OnChainNotarization } from '@iota/notarization/web';
-import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { replaceJsonKeyValue } from '~/lib';
 
 interface NotarizationState {
@@ -12,40 +12,39 @@ interface NotarizationState {
     metadata?: string;
 }
 
-export function useNotarizationState(notarization: OnChainNotarization) {
-    return useQuery<NotarizationState | null>({
-        queryKey: ['notarizationState', notarization.id, notarization.state],
-        queryFn: async () => {
-            const state = notarization.state;
-            let content: string;
-            let lang = 'text';
+export function useNotarizationState(notarization: OnChainNotarization): NotarizationState | null {
+    const state = notarization.state;
+    if (!state) {
+        return null;
+    }
 
-            if (!state) {
-                return null;
+    const [content, lang] = useMemo((): [string, string] => {
+        let stateContent: string;
+        let contentLang = 'text';
+
+        const dataValue = state.data.value;
+        if (typeof dataValue !== 'string') {
+            // If dataValue is not a string then it is certainly a byte state
+            stateContent = encodeB64(state.data.toBytes());
+            contentLang = 'text';
+        } else {
+            // Try to parse the string state as JSON first, otherwise show the string
+            try {
+                const json = JSON.parse(dataValue);
+                stateContent = JSON.stringify(json, replaceJsonKeyValue, 2);
+                contentLang = 'json';
+            } catch (e) {
+                stateContent = dataValue;
+                contentLang = 'text';
             }
+        }
 
-            const dataValue = state.data.value;
-            if (typeof dataValue !== 'string') {
-                // If dataValue is not a string then it is certainly a byte state
-                content = encodeB64(state.data.toBytes());
-                lang = 'text';
-            } else {
-                // Try to parse the string state as JSON first, otherwise show the string
-                try {
-                    const json = JSON.parse(dataValue);
-                    content = JSON.stringify(json, replaceJsonKeyValue, 2);
-                    lang = 'json';
-                } catch (e) {
-                    content = dataValue;
-                    lang = 'text';
-                }
-            }
+        return [stateContent, contentLang];
+    }, [state]);
 
-            return {
-                content,
-                lang,
-                metadata: state.metadata,
-            };
-        },
-    });
+    return {
+        content,
+        lang,
+        metadata: state.metadata,
+    };
 }

--- a/apps/explorer/src/hooks/useNotarizationState.ts
+++ b/apps/explorer/src/hooks/useNotarizationState.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { encodeB64 } from '@iota/identity-wasm/web';
+import type { OnChainNotarization } from '@iota/notarization/web';
+import { useQuery } from '@tanstack/react-query';
+import { replaceJsonKeyValue } from '~/lib';
+
+interface NotarizationState {
+    content: string;
+    lang: string;
+    metadata?: string;
+}
+
+export function useNotarizationState(notarization: OnChainNotarization) {
+    return useQuery<NotarizationState | null>({
+        queryKey: ['notarizationState', notarization.id, notarization.state],
+        queryFn: async () => {
+            const state = notarization.state;
+            let content: string;
+            let lang = 'text';
+
+            if (!state) {
+                return null;
+            }
+
+            const dataValue = state.data.value;
+            if (typeof dataValue !== 'string') {
+                // If dataValue is not a string then it is certainly a byte state
+                content = encodeB64(state.data.toBytes());
+                lang = 'text';
+            } else {
+                // Try to parse the string state as JSON first, otherwise show the string
+                try {
+                    const json = JSON.parse(dataValue);
+                    content = JSON.stringify(json, replaceJsonKeyValue, 2);
+                    lang = 'json';
+                } catch (e) {
+                    content = dataValue;
+                    lang = 'text';
+                }
+            }
+
+            return {
+                content,
+                lang,
+                metadata: state?.metadata,
+            };
+        },
+    });
+}

--- a/apps/explorer/src/hooks/useNotarizationState.ts
+++ b/apps/explorer/src/hooks/useNotarizationState.ts
@@ -44,7 +44,7 @@ export function useNotarizationState(notarization: OnChainNotarization) {
             return {
                 content,
                 lang,
-                metadata: state?.metadata,
+                metadata: state.metadata,
             };
         },
     });

--- a/apps/explorer/src/hooks/useResolveNotarization.ts
+++ b/apps/explorer/src/hooks/useResolveNotarization.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { type OnChainNotarization } from '@iota/notarization/web';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useNotarizationClient } from '~/contexts';
+
+/**
+ * A React hook that resolves an Object ID to its corresponding Notarization document on chain.
+ *
+ * @param {string} objectId - The Object ID to resolve.
+ * @returns a Notarization document on chain.
+ */
+export function useResolveNotarization(objectId: string): UseQueryResult<OnChainNotarization> {
+    const notarizationClient = useNotarizationClient();
+    return useQuery({
+        queryKey: ['resolve-notarization', objectId],
+        queryFn: async () => notarizationClient?.getNotarizationById(objectId),
+        enabled: !!notarizationClient,
+    });
+}

--- a/apps/explorer/src/lib/utils/stringUtils.ts
+++ b/apps/explorer/src/lib/utils/stringUtils.ts
@@ -30,3 +30,7 @@ export async function genFileTypeMsg(displayString: string, signal: AbortSignal)
 export function isString(value: unknown): boolean {
     return typeof value === 'string';
 }
+
+export function replaceJsonKeyValue(_key: unknown, value: unknown) {
+    return typeof value === 'bigint' ? value.toString() : value;
+}

--- a/apps/explorer/src/pages/index.tsx
+++ b/apps/explorer/src/pages/index.tsx
@@ -16,6 +16,7 @@ import { ValidatorDetails } from './validator/ValidatorDetails';
 import { ValidatorPageResult } from './validators/Validators';
 import { Layout } from '~/components';
 import { IdentityResult } from './trust-framework/identity-result/IdentityResult';
+import { NotarizationResult } from './trust-framework/notarization-result/NotarizationResult';
 
 interface RedirectWithIdProps {
     base: string;
@@ -46,6 +47,7 @@ export const router = sentryCreateBrowserRouter([
             { path: 'validators', element: <ValidatorPageResult /> },
             { path: 'validator/:id', element: <ValidatorDetails /> },
             { path: 'identity/:id', element: <IdentityResult /> },
+            { path: 'notarization/:id', element: <NotarizationResult /> },
         ],
     },
     {

--- a/apps/explorer/src/pages/trust-framework/headerMetadataHelper.ts
+++ b/apps/explorer/src/pages/trust-framework/headerMetadataHelper.ts
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { IotaObjectData } from '@iota/iota-sdk/client';
+import { parseStructTag } from '@iota/iota-sdk/utils';
+import { type OnChainNotarization } from '@iota/notarization/web';
 import { type MetaItem } from '~/components/ui/PageHeaderMeta';
 
 const IDENTITY_MODULE = 'identity';
 const IDENTITY_METHOD = 'Identity';
+const NOTARIZATION_MODULE = 'notarization';
+const NOTARIZATION_METHOD = 'Notarization';
 
 const metadata = {
     objectLegacyId: {
@@ -16,6 +20,15 @@ const metadata = {
         label: 'Type',
         visible: true,
         badge: 'IOTA Identity',
+    },
+    notarizationMethod: {
+        label: 'Method',
+        visible: true,
+    },
+    notarizationType: {
+        label: 'Type',
+        visible: true,
+        badge: 'IOTA Notarization',
     },
 };
 
@@ -104,5 +117,55 @@ export function getLegacyMetadata(didObject: IotaObjectData | null): MetaItem | 
         label: metadata.objectLegacyId.label,
         value: legacyId,
         visible: metadata.objectLegacyId.visible,
+    } as MetaItem;
+}
+
+export function getNotarizationMethod(notarizationDocument: OnChainNotarization): MetaItem {
+    return {
+        label: metadata.notarizationMethod.label,
+        value: notarizationDocument.method,
+        visible: metadata.notarizationMethod.visible,
+    };
+}
+
+/**
+ * Determines the notarization type of an Notarization Object based on its type.
+ *
+ * @param notarizationObject - The IOTA object data to analyze.
+ * @param pkgId - The package ID to compare against for official notarization package.
+ * @returns A MetaItem object containing identity type information, or null if
+ *          the objectData is null or has no type.
+ */
+export function getNotarizationType(
+    notarizationObject: IotaObjectData | null,
+    pkgId: string,
+): MetaItem | null {
+    if (notarizationObject == null || notarizationObject.type == null) {
+        return null;
+    }
+
+    const tooltipText =
+        'The method used to create and resolve this Notarization. "IOTA Notarization" is the Foundation\'s official notarization framework, anchored onchain on IOTA L1.';
+
+    const {
+        address: _package,
+        module: _module,
+        name: _method,
+    } = parseStructTag(notarizationObject.type);
+    if (_method === NOTARIZATION_METHOD && _module === NOTARIZATION_MODULE && _package === pkgId) {
+        // Official Notarization package for the current network
+        return {
+            label: metadata.notarizationType.label,
+            value: metadata.notarizationType.badge,
+            visible: metadata.notarizationType.visible,
+            tooltipText,
+        } as MetaItem;
+    }
+
+    return {
+        label: metadata.identityType.label,
+        value: notarizationObject.type,
+        visible: metadata.identityType.visible,
+        tooltipText,
     } as MetaItem;
 }

--- a/apps/explorer/src/pages/trust-framework/headerMetadataHelper.ts
+++ b/apps/explorer/src/pages/trust-framework/headerMetadataHelper.ts
@@ -163,9 +163,9 @@ export function getNotarizationType(
     }
 
     return {
-        label: metadata.identityType.label,
+        label: metadata.notarizationType.label,
         value: notarizationObject.type,
-        visible: metadata.identityType.visible,
+        visible: metadata.notarizationType.visible,
         tooltipText,
     } as MetaItem;
 }

--- a/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationContent.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationContent.tsx
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { InfoBox, InfoBoxStyle, InfoBoxType } from '@iota/apps-ui-kit';
+import { AddressAlias, useCopyToClipboard, useGetObjectOrPastObject } from '@iota/core';
+import { PageHeader, PageLayout } from '~/components';
+import { onCopySuccess } from '~/lib';
+import { useNotarizationPkgId } from '~/contexts';
+import { useMemo } from 'react';
+import { Warning } from '@iota/apps-ui-icons';
+import {
+    getNotarizationMethod,
+    getNotarizationType,
+    MetadataBuilder,
+} from '../headerMetadataHelper';
+import { useResolveNotarization } from '~/hooks/useResolveNotarization';
+import { NotarizastionSummaryView } from './views/NotarizationSummaryView';
+// import { LockLifecycleView } from './views/LockLifecycleView';
+// import { OwnersView } from './views/OwnersView';
+// import { SideBySidePanels } from '~/components/ui/SideBySidePanels';
+import { TransactionsView } from '../common/TransactionsView';
+import { StateView } from './views/StateView';
+import { NotarizationJsonView } from './views/NotarizationJsonView';
+
+interface NotarizationContentProps {
+    objectId: string;
+}
+
+export function NotarizationContent({ objectId }: NotarizationContentProps) {
+    const { data: objectResult, isPending: isObjectPending } = useGetObjectOrPastObject(objectId);
+    const { data: notarizationDocument, isPending: isNotarizationPending } =
+        useResolveNotarization(objectId);
+
+    const copyToClipboard = useCopyToClipboard(onCopySuccess);
+    const iotaNotarizationPackage = useNotarizationPkgId();
+
+    const isPending = useMemo(
+        () => isNotarizationPending || isObjectPending,
+        [isNotarizationPending, isObjectPending],
+    );
+    if (isPending) {
+        return (
+            <PageLayout
+                loading
+                loadingText="Loading Notarization Document and Object..."
+                content={[]}
+            />
+        );
+    }
+
+    if (notarizationDocument == null) {
+        return (
+            <PageLayout
+                content={
+                    <InfoBox
+                        title="Error resolving Notarization Document"
+                        supportingText={`Could not resolve Notarization ${objectId} in the current network.`}
+                        icon={<Warning />}
+                        type={InfoBoxType.Error}
+                        style={InfoBoxStyle.Elevated}
+                    />
+                }
+            />
+        );
+    }
+
+    if (objectResult == null) {
+        return (
+            <PageLayout
+                content={
+                    <InfoBox
+                        title="Error fetching Notarization Object"
+                        supportingText={`Could not fetch Object ID ${objectId} from the current network.`}
+                        icon={<Warning />}
+                        type={InfoBoxType.Error}
+                        style={InfoBoxStyle.Elevated}
+                    />
+                }
+            />
+        );
+    }
+
+    if (iotaNotarizationPackage == null) {
+        // The activation of this branch is a symptom of Notarization WASM Web module not loaded.
+        return (
+            <PageLayout
+                content={
+                    <InfoBox
+                        title="Error loading official Notarization package"
+                        supportingText="Could not load package ID from Notarization client."
+                        icon={<Warning />}
+                        type={InfoBoxType.Error}
+                        style={InfoBoxStyle.Elevated}
+                    />
+                }
+            />
+        );
+    }
+
+    return (
+        <PageLayout
+            content={
+                <div className="flex flex-col gap-y-2xl">
+                    <PageHeader
+                        type="Notarization"
+                        title={
+                            <AddressAlias
+                                address={objectId || ''}
+                                onCopy={() => copyToClipboard(objectId || '')}
+                            />
+                        }
+                        showCopyButton={false}
+                        metaItems={MetadataBuilder.create()
+                            .addItem(
+                                getNotarizationType(
+                                    objectResult.data || null,
+                                    iotaNotarizationPackage,
+                                ),
+                            )
+                            .addItem(getNotarizationMethod(notarizationDocument))
+                            .build()}
+                    />
+                    <NotarizastionSummaryView
+                        objectData={objectResult.data!}
+                        notarizationDocument={notarizationDocument}
+                    />
+                    {/* <SideBySidePanels */}
+                    {/*     firstPanel={ */}
+                    {/*         <LockLifecycleView */}
+                    {/*             locking={notarizationDocument.immutableMetadata.locking} */}
+                    {/*         /> */}
+                    {/*     } */}
+                    {/*     secondPanel={<OwnersView objectId={objectId} />} */}
+                    {/* /> */}
+                    <StateView notarization={notarizationDocument} />
+                    <NotarizationJsonView notarization={notarizationDocument} />
+                    <TransactionsView objectId={objectId} />
+                </div>
+            }
+        />
+    );
+}

--- a/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationContent.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationContent.tsx
@@ -6,7 +6,6 @@ import { AddressAlias, useCopyToClipboard, useGetObjectOrPastObject } from '@iot
 import { PageHeader, PageLayout } from '~/components';
 import { onCopySuccess } from '~/lib';
 import { useNotarizationPkgId } from '~/contexts';
-import { useMemo } from 'react';
 import { Warning } from '@iota/apps-ui-icons';
 import {
     getNotarizationMethod,
@@ -34,10 +33,7 @@ export function NotarizationContent({ objectId }: NotarizationContentProps) {
     const copyToClipboard = useCopyToClipboard(onCopySuccess);
     const iotaNotarizationPackage = useNotarizationPkgId();
 
-    const isPending = useMemo(
-        () => isNotarizationPending || isObjectPending,
-        [isNotarizationPending, isObjectPending],
-    );
+    const isPending = isNotarizationPending || isObjectPending;
     if (isPending) {
         return (
             <PageLayout

--- a/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationContent.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationContent.tsx
@@ -13,7 +13,7 @@ import {
     MetadataBuilder,
 } from '../headerMetadataHelper';
 import { useResolveNotarization } from '~/hooks/useResolveNotarization';
-import { NotarizastionSummaryView } from './views/NotarizationSummaryView';
+import { NotarizationSummaryView } from './views/NotarizationSummaryView';
 // import { LockLifecycleView } from './views/LockLifecycleView';
 // import { OwnersView } from './views/OwnersView';
 // import { SideBySidePanels } from '~/components/ui/SideBySidePanels';
@@ -116,7 +116,7 @@ export function NotarizationContent({ objectId }: NotarizationContentProps) {
                             .addItem(getNotarizationMethod(notarizationDocument))
                             .build()}
                     />
-                    <NotarizastionSummaryView
+                    <NotarizationSummaryView
                         objectData={objectResult.data!}
                         notarizationDocument={notarizationDocument}
                     />

--- a/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationContent.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationContent.tsx
@@ -14,9 +14,6 @@ import {
 } from '../headerMetadataHelper';
 import { useResolveNotarization } from '~/hooks/useResolveNotarization';
 import { NotarizationSummaryView } from './views/NotarizationSummaryView';
-// import { LockLifecycleView } from './views/LockLifecycleView';
-// import { OwnersView } from './views/OwnersView';
-// import { SideBySidePanels } from '~/components/ui/SideBySidePanels';
 import { TransactionsView } from '../common/TransactionsView';
 import { StateView } from './views/StateView';
 import { NotarizationJsonView } from './views/NotarizationJsonView';
@@ -120,14 +117,6 @@ export function NotarizationContent({ objectId }: NotarizationContentProps) {
                         objectData={objectResult.data!}
                         notarizationDocument={notarizationDocument}
                     />
-                    {/* <SideBySidePanels */}
-                    {/*     firstPanel={ */}
-                    {/*         <LockLifecycleView */}
-                    {/*             locking={notarizationDocument.immutableMetadata.locking} */}
-                    {/*         /> */}
-                    {/*     } */}
-                    {/*     secondPanel={<OwnersView objectId={objectId} />} */}
-                    {/* /> */}
                     <StateView notarization={notarizationDocument} />
                     <NotarizationJsonView notarization={notarizationDocument} />
                     <TransactionsView objectId={objectId} />

--- a/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationResult.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationResult.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { InfoBox, InfoBoxStyle, InfoBoxType } from '@iota/apps-ui-kit';
+import { useParams } from 'react-router-dom';
+import { PageLayout } from '~/components';
+import { Warning } from '@iota/apps-ui-icons';
+import { NotarizationContent } from './NotarizationContent';
+
+export function NotarizationResult() {
+    const { id: notarizationId } = useParams();
+
+    if (notarizationId == null) {
+        return (
+            <PageLayout
+                content={
+                    <InfoBox
+                        title="Notarization not implemented yet!"
+                        supportingText="Wait for the notarization implementation."
+                        icon={<Warning />}
+                        type={InfoBoxType.Error}
+                        style={InfoBoxStyle.Elevated}
+                    />
+                }
+            />
+        );
+    }
+
+    return <NotarizationContent objectId={notarizationId} />;
+}

--- a/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationResult.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationResult.tsx
@@ -15,8 +15,8 @@ export function NotarizationResult() {
             <PageLayout
                 content={
                     <InfoBox
-                        title="Notarization not implemented yet!"
-                        supportingText="Wait for the notarization implementation."
+                        title="Missing Notarization ID"
+                        supportingText="The path is missing a Notarization ID to parse."
                         icon={<Warning />}
                         type={InfoBoxType.Error}
                         style={InfoBoxStyle.Elevated}

--- a/apps/explorer/src/pages/trust-framework/notarization-result/views/NotarizationJsonView.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/views/NotarizationJsonView.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { Title, TooltipPosition } from '@iota/apps-ui-kit';
+import { type OnChainNotarization } from '@iota/notarization/web';
+import { Panel, PanelGroup } from 'react-resizable-panels';
+import { ErrorBoundary, SyntaxHighlighter } from '~/components';
+import { replaceJsonKeyValue } from '~/lib';
+
+interface NotarizationJsonViewProps {
+    notarization: OnChainNotarization;
+}
+
+export function NotarizationJsonView({ notarization }: NotarizationJsonViewProps) {
+    return (
+        <ErrorBoundary>
+            <div className="panel-bg flex w-full flex-col rounded-xl border border-transparent p-md--rs">
+                <PanelGroup direction="horizontal">
+                    <Panel>
+                        <div className="flex w-full flex-col gap-sm">
+                            <Title
+                                title="Notarization"
+                                tooltipPosition={TooltipPosition.Left}
+                                tooltipText="The raw JSON representation of the On-Chain Notarization. This includes the state, metadata, and other properties of the notarization."
+                            />
+                            <div className="flex flex-col">
+                                <SyntaxHighlighter
+                                    code={JSON.stringify(
+                                        notarization?.toJSON(),
+                                        replaceJsonKeyValue,
+                                        2,
+                                    )}
+                                    language="json"
+                                />
+                            </div>
+                        </div>
+                    </Panel>
+                </PanelGroup>
+            </div>
+        </ErrorBoundary>
+    );
+}

--- a/apps/explorer/src/pages/trust-framework/notarization-result/views/NotarizationSummaryView.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/views/NotarizationSummaryView.tsx
@@ -16,7 +16,7 @@ interface NotarizationSummaryViewProps {
     objectData: IotaObjectData;
 }
 
-export function NotarizastionSummaryView({
+export function NotarizationSummaryView({
     notarizationDocument,
     objectData,
 }: NotarizationSummaryViewProps): JSX.Element {

--- a/apps/explorer/src/pages/trust-framework/notarization-result/views/NotarizationSummaryView.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/views/NotarizationSummaryView.tsx
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { DisplayStats, TooltipPosition } from '@iota/apps-ui-kit';
+import { formatDate, useFormatCoin } from '@iota/core';
+import { type IotaObjectData } from '@iota/iota-sdk/client';
+import { CoinFormat, formatDigest } from '@iota/iota-sdk/utils';
+import clsx from 'clsx';
+import { ObjectLink, TransactionLink } from '~/components/ui';
+import { onCopySuccess } from '~/lib/utils';
+import { ErrorBoundary } from '~/components';
+import { type OnChainNotarization } from '@iota/notarization/web';
+
+interface NotarizationSummaryViewProps {
+    notarizationDocument: OnChainNotarization;
+    objectData: IotaObjectData;
+}
+
+export function NotarizastionSummaryView({
+    notarizationDocument,
+    objectData,
+}: NotarizationSummaryViewProps): JSX.Element {
+    const objectId = objectData?.objectId;
+    const storageRebate = objectData?.storageRebate;
+    const versionCount = `v${notarizationDocument.stateVersionCount}`;
+
+    const dateFormat = (timestamp: bigint): string =>
+        // Convert seconds to milliseconds for Date constructor
+        formatDate(new Date(Number(timestamp)), ['year', 'month', 'day', 'hour', 'minute']);
+    const createdAt = dateFormat(notarizationDocument.immutableMetadata.createdAt);
+    const updatedAt = dateFormat(notarizationDocument.lastStateChangeAt);
+    const lastTransactionBlockDigest = objectData?.previousTransaction;
+
+    return (
+        <ErrorBoundary>
+            <div className="flex flex-col gap-md">
+                <div className={clsx('address-grid-container-top', 'no-image', 'no-description')}>
+                    {objectId && (
+                        <div>
+                            <ObjectIdCard objectId={objectId} />
+                        </div>
+                    )}
+
+                    {versionCount && (
+                        <div>
+                            <DisplayStats
+                                label="Version"
+                                value={versionCount}
+                                tooltipPosition={TooltipPosition.Left}
+                                tooltipText="Version of state change in a progressive sequence."
+                            />
+                        </div>
+                    )}
+
+                    {storageRebate && (
+                        <div>
+                            <StorageRebateCard storageRebate={storageRebate} />
+                        </div>
+                    )}
+
+                    {createdAt && (
+                        <div>
+                            <DisplayStats
+                                label="Created at"
+                                value={createdAt}
+                                tooltipPosition={TooltipPosition.Left}
+                                tooltipText="Timestamp of the transaction that first published this notarization onchain."
+                            />
+                        </div>
+                    )}
+
+                    {updatedAt && (
+                        <div>
+                            <DisplayStats
+                                label="Updated at"
+                                value={updatedAt}
+                                tooltipPosition={TooltipPosition.Left}
+                                tooltipText="Timestamp of the most recent transaction that modified this notarization. The version badge shows the current state version count."
+                            />
+                        </div>
+                    )}
+
+                    {lastTransactionBlockDigest && (
+                        <div>
+                            <LastTxBlockCard digest={lastTransactionBlockDigest} />
+                        </div>
+                    )}
+                </div>
+            </div>
+        </ErrorBoundary>
+    );
+}
+
+interface ObjectIdCardProps {
+    objectId: string;
+}
+
+function ObjectIdCard({ objectId }: ObjectIdCardProps): JSX.Element {
+    return (
+        <DisplayStats
+            label="Object ID"
+            value={
+                <div className="flex flex-col gap-xs">
+                    <ObjectLink objectId={objectId} copyText={objectId} />
+                </div>
+            }
+            tooltipPosition={TooltipPosition.Left}
+            tooltipText="The unique onchain identifier of the Move object storing this notarization's state."
+        />
+    );
+}
+
+interface LastTxBlockCardProps {
+    digest: string;
+}
+
+function LastTxBlockCard({ digest }: LastTxBlockCardProps): JSX.Element {
+    return (
+        <DisplayStats
+            label="Last Transaction Block Digest"
+            value={<TransactionLink digest={digest}>{formatDigest(digest)}</TransactionLink>}
+            copyText={digest}
+            onCopySuccess={onCopySuccess}
+            tooltipPosition={TooltipPosition.Left}
+            tooltipText="Hash of the most recent transaction that modified this notarization. Use it to inspect transaction details on the explorer."
+        />
+    );
+}
+
+interface StorageRebateCardProps {
+    storageRebate: string;
+}
+
+function StorageRebateCard({ storageRebate }: StorageRebateCardProps): JSX.Element | null {
+    const [storageRebateFormatted, symbol] = useFormatCoin({
+        balance: storageRebate,
+        format: CoinFormat.Full,
+    });
+
+    return (
+        <DisplayStats
+            label="Storage Rebate"
+            value={`-${storageRebateFormatted}`}
+            supportingLabel={symbol}
+            tooltipPosition={TooltipPosition.Left}
+            tooltipText="IOTA tokens locked as a storage deposit for this object. Partially refundable when the object is deleted or reduced in size."
+        />
+    );
+}

--- a/apps/explorer/src/pages/trust-framework/notarization-result/views/NotarizationSummaryView.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/views/NotarizationSummaryView.tsx
@@ -20,8 +20,8 @@ export function NotarizastionSummaryView({
     notarizationDocument,
     objectData,
 }: NotarizationSummaryViewProps): JSX.Element {
-    const objectId = objectData?.objectId;
-    const storageRebate = objectData?.storageRebate;
+    const objectId = objectData.objectId;
+    const storageRebate = objectData.storageRebate;
     const versionCount = `v${notarizationDocument.stateVersionCount}`;
 
     const dateFormat = (timestamp: bigint): string =>
@@ -29,7 +29,7 @@ export function NotarizastionSummaryView({
         formatDate(new Date(Number(timestamp)), ['year', 'month', 'day', 'hour', 'minute']);
     const createdAt = dateFormat(notarizationDocument.immutableMetadata.createdAt);
     const updatedAt = dateFormat(notarizationDocument.lastStateChangeAt);
-    const lastTransactionBlockDigest = objectData?.previousTransaction;
+    const lastTransactionBlockDigest = objectData.previousTransaction;
 
     return (
         <ErrorBoundary>

--- a/apps/explorer/src/pages/trust-framework/notarization-result/views/StateView.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/views/StateView.tsx
@@ -1,7 +1,15 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { Title, TooltipPosition } from '@iota/apps-ui-kit';
+import { Warning } from '@iota/apps-ui-icons';
+import {
+    InfoBox,
+    InfoBoxStyle,
+    InfoBoxType,
+    LoadingIndicator,
+    Title,
+    TooltipPosition,
+} from '@iota/apps-ui-kit';
 import { type OnChainNotarization } from '@iota/notarization/web';
 import { Panel, PanelGroup } from 'react-resizable-panels';
 import { ErrorBoundary, SyntaxHighlighter } from '~/components';
@@ -12,30 +20,47 @@ interface StateViewProps {
 }
 
 export function StateView({ notarization }: StateViewProps) {
-    const { data, isLoading, error } = useNotarizationState(notarization);
+    const { data, isPending, isError, isSuccess } = useNotarizationState(notarization);
 
-    if (isLoading) {
-        return <div>Loading...</div>;
+    if (isError) {
+        return (
+            <InfoBox
+                title="Error Parsing Notarization State"
+                supportingText={`Could not parse state of notarization ${notarization.id} on the current network.`}
+                icon={<Warning />}
+                type={InfoBoxType.Error}
+                style={InfoBoxStyle.Elevated}
+            />
+        );
     }
 
-    if (error) {
-        return <div>Error: {error.message}</div>;
-    }
-
-    const { content, lang, metadata } = data!;
-
-    return (
-        <ErrorBoundary>
-            <div className="panel-bg flex h-full w-full flex-col gap-sm--rs rounded-xl border border-transparent p-md--rs">
-                <PanelGroup direction="horizontal">
-                    <StatePanel content={content} lang={lang} />
-                </PanelGroup>
-                <PanelGroup direction="horizontal">
-                    <MetadataPanel metadata={metadata} />
-                </PanelGroup>
+    if (isPending) {
+        return (
+            <div className="flex justify-center">
+                <LoadingIndicator size="w-6 h-6" text="Loading state and metadata..." />
             </div>
-        </ErrorBoundary>
-    );
+        );
+    }
+
+    if (isSuccess) {
+        const { content, lang, metadata } = data!;
+        return (
+            <ErrorBoundary>
+                <div className="panel-bg flex h-full w-full flex-col gap-sm--rs rounded-xl border border-transparent p-md--rs">
+                    {content && (
+                        <PanelGroup direction="horizontal">
+                            <StatePanel content={content} lang={lang} />
+                        </PanelGroup>
+                    )}
+                    {metadata && (
+                        <PanelGroup direction="horizontal">
+                            <MetadataPanel metadata={metadata} />
+                        </PanelGroup>
+                    )}
+                </div>
+            </ErrorBoundary>
+        );
+    }
 }
 
 function StatePanel({ content, lang }: { content: string; lang: string }) {

--- a/apps/explorer/src/pages/trust-framework/notarization-result/views/StateView.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/views/StateView.tsx
@@ -1,15 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { Warning } from '@iota/apps-ui-icons';
-import {
-    InfoBox,
-    InfoBoxStyle,
-    InfoBoxType,
-    LoadingIndicator,
-    Title,
-    TooltipPosition,
-} from '@iota/apps-ui-kit';
+import { Title, TooltipPosition } from '@iota/apps-ui-kit';
 import { type OnChainNotarization } from '@iota/notarization/web';
 import { Panel, PanelGroup } from 'react-resizable-panels';
 import { ErrorBoundary, SyntaxHighlighter } from '~/components';
@@ -20,47 +12,29 @@ interface StateViewProps {
 }
 
 export function StateView({ notarization }: StateViewProps) {
-    const { data, isPending, isError, isSuccess } = useNotarizationState(notarization);
+    const data = useNotarizationState(notarization);
 
-    if (isError) {
-        return (
-            <InfoBox
-                title="Error Parsing Notarization State"
-                supportingText={`Could not parse state of notarization ${notarization.id} on the current network.`}
-                icon={<Warning />}
-                type={InfoBoxType.Error}
-                style={InfoBoxStyle.Elevated}
-            />
-        );
+    if (data == null) {
+        return;
     }
 
-    if (isPending) {
-        return (
-            <div className="flex justify-center">
-                <LoadingIndicator size="w-6 h-6" text="Loading state and metadata..." />
+    const { content, lang, metadata } = data!;
+    return (
+        <ErrorBoundary>
+            <div className="panel-bg flex h-full w-full flex-col gap-sm--rs rounded-xl border border-transparent p-md--rs">
+                {content && (
+                    <PanelGroup direction="horizontal">
+                        <StatePanel content={content} lang={lang} />
+                    </PanelGroup>
+                )}
+                {metadata && (
+                    <PanelGroup direction="horizontal">
+                        <MetadataPanel metadata={metadata} />
+                    </PanelGroup>
+                )}
             </div>
-        );
-    }
-
-    if (isSuccess) {
-        const { content, lang, metadata } = data!;
-        return (
-            <ErrorBoundary>
-                <div className="panel-bg flex h-full w-full flex-col gap-sm--rs rounded-xl border border-transparent p-md--rs">
-                    {content && (
-                        <PanelGroup direction="horizontal">
-                            <StatePanel content={content} lang={lang} />
-                        </PanelGroup>
-                    )}
-                    {metadata && (
-                        <PanelGroup direction="horizontal">
-                            <MetadataPanel metadata={metadata} />
-                        </PanelGroup>
-                    )}
-                </div>
-            </ErrorBoundary>
-        );
-    }
+        </ErrorBoundary>
+    );
 }
 
 function StatePanel({ content, lang }: { content: string; lang: string }) {

--- a/apps/explorer/src/pages/trust-framework/notarization-result/views/StateView.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/views/StateView.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { Title, TooltipPosition } from '@iota/apps-ui-kit';
+import { type OnChainNotarization } from '@iota/notarization/web';
+import { Panel, PanelGroup } from 'react-resizable-panels';
+import { ErrorBoundary, SyntaxHighlighter } from '~/components';
+import { useNotarizationState } from '~/hooks/useNotarizationState';
+
+interface StateViewProps {
+    notarization: OnChainNotarization;
+}
+
+export function StateView({ notarization }: StateViewProps) {
+    const { data, isLoading, error } = useNotarizationState(notarization);
+
+    if (isLoading) {
+        return <div>Loading...</div>;
+    }
+
+    if (error) {
+        return <div>Error: {error.message}</div>;
+    }
+
+    const { content, lang, metadata } = data!;
+
+    return (
+        <ErrorBoundary>
+            <div className="panel-bg flex h-full w-full flex-col gap-sm--rs rounded-xl border border-transparent p-md--rs">
+                <PanelGroup direction="horizontal">
+                    <StatePanel content={content} lang={lang} />
+                </PanelGroup>
+                <PanelGroup direction="horizontal">
+                    <MetadataPanel metadata={metadata} />
+                </PanelGroup>
+            </div>
+        </ErrorBoundary>
+    );
+}
+
+function StatePanel({ content, lang }: { content: string; lang: string }) {
+    return (
+        <Panel defaultSize={60} minSize={20}>
+            <div className="flex h-full w-full flex-col gap-sm">
+                <Title
+                    title="Notarization State"
+                    tooltipPosition={TooltipPosition.Left}
+                    tooltipText="The state data of this Notarization. Displayed as text if valid UTF-8, otherwise as Base64."
+                />
+                <div className="flex flex-col">
+                    <SyntaxHighlighter code={content} language={lang} />
+                </div>
+            </div>
+        </Panel>
+    );
+}
+
+function MetadataPanel({ metadata }: { metadata?: string }) {
+    return (
+        <Panel defaultSize={40} minSize={20}>
+            <div className="flex h-full w-full flex-col gap-sm">
+                <Title
+                    title="State Metadata"
+                    tooltipPosition={TooltipPosition.Left}
+                    tooltipText="The metadata associated with the state."
+                />
+                <div className="flex flex-col">
+                    <SyntaxHighlighter code={metadata!} language="text" />
+                </div>
+            </div>
+        </Panel>
+    );
+}


### PR DESCRIPTION
# Description of change

This PR introduces the **Notarization Result Page** to the Explorer, providing users with a dedicated interface to inspect on-chain Notarization documents and their current states. 

### Key Features and Changes
- **Dedicated Routing:** Added a new `/notarization/:id` route (`NotarizationResult`) to handle direct navigation to Notarization objects.
- **Detailed Views:**
  - `NotarizationSummaryView`: Displays essential object metrics, including version count, storage rebate, and lifecycle timestamps.
  - `StateView`: Intelligently parses the notarization state data, rendering it as formatted JSON or falling back to raw text/Base64 if needed.
  - `NotarizationJsonView`: Exposes the raw, complete JSON structure of the on-chain notarization object.
- **Data Resolution Hooks:** Introduced `useResolveNotarization` and `useNotarizationState` to cleanly handle data fetching and state decoding.
- **Metadata Integration:** Updated `headerMetadataHelper.ts` to correctly recognize, label, and badge official IOTA Notarization objects in the shared `PageHeader`.

## Links to any relevant issues

N/A

## How the change has been tested

Access the _Preview_ at https://rebased-explorer-git-feat-notarization-result-page-iota1.vercel.app/notarization/0x23be2a1a617f0af6830ffe328c357df7c73de25b2013eef362e8cc09f9df9f57?network=testnet to see a Dynamic notarization object.

Refer to https://github.com/iotaledger/ts-packages/pull/138#issue-4315699223 at _Test on testnet_ section to get more notarization objects IDs.

## Screenshot

<img width="5388" height="5026" alt="image" src="https://github.com/user-attachments/assets/8907360f-44a7-4b72-a4cf-7340b0fb184a" />

