### PR TITLE
feat(explorer): notarization lock and owner views

### DIFF
--- a/apps/explorer/.env.example
+++ b/apps/explorer/.env.example
@@ -3,3 +3,5 @@ VITE_AMPLITUDE_ENABLED='false'
 VITE_SENTRY_ENABLED='false'
 # On local test network create an identity package first
 VITE_IOTA_IDENTITY_PKG_ID=xxxxxxx
+# On local test network create a notarization package first
+VITE_IOTA_NOTARIZATION_PKG_ID=xxxxxxx

--- a/apps/explorer/src/components/ui/IconBadge.tsx
+++ b/apps/explorer/src/components/ui/IconBadge.tsx
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import clsx from 'clsx';
+import { BadgeType } from '@iota/apps-ui-kit';
+import type { ReactNode } from 'react';
+
+interface IconBadgeProps {
+    type: BadgeType;
+    label: string;
+    icon: ReactNode;
+}
+
+const BACKGROUND_COLORS: Record<BadgeType, string> = {
+    [BadgeType.PrimarySolid]: 'badge-bg-color-primary',
+    [BadgeType.Neutral]: 'badge-bg-color-neutral',
+    [BadgeType.PrimarySoft]: 'badge-bg-color-primary-soft',
+    [BadgeType.Success]: 'bg-success-surface',
+    [BadgeType.Warning]: 'bg-warning-surface',
+    [BadgeType.Error]: 'bg-error-surface',
+};
+
+const TEXT_COLORS: Record<BadgeType, string> = {
+    [BadgeType.PrimarySolid]: 'badge-text-color-primary',
+    [BadgeType.Neutral]: 'badge-text-color-neutral',
+    [BadgeType.PrimarySoft]: 'badge-text-color-primary-soft',
+    [BadgeType.Success]: 'text-on-success',
+    [BadgeType.Warning]: 'text-on-warning',
+    [BadgeType.Error]: 'text-on-error',
+};
+
+const BORDER_COLORS: Record<BadgeType, string> = {
+    [BadgeType.PrimarySolid]: 'badge-border-color-primary',
+    [BadgeType.Neutral]: 'badge-border-color-neutral',
+    [BadgeType.PrimarySoft]: 'badge-border-color-soft',
+    [BadgeType.Success]: 'border-success-surface',
+    [BadgeType.Warning]: 'border-warning-surface',
+    [BadgeType.Error]: 'border-error-surface',
+};
+
+export function IconBadge({ type, label, icon }: IconBadgeProps): React.JSX.Element {
+    return (
+        <div
+            className={clsx(
+                'inline-flex items-center gap-0.5 rounded-full border px-xs py-xxs',
+                BACKGROUND_COLORS[type],
+                BORDER_COLORS[type],
+            )}
+        >
+            <span className={clsx('flex h-4 w-4 items-center justify-center', TEXT_COLORS[type])}>
+                {icon}
+            </span>
+            <span className={clsx('text-label-md', TEXT_COLORS[type])}>{label}</span>
+        </div>
+    );
+}

--- a/apps/explorer/src/components/ui/index.ts
+++ b/apps/explorer/src/components/ui/index.ts
@@ -6,6 +6,7 @@ export * from './header';
 export * from './modal';
 
 export * from './ButtonOrLink';
+export * from './IconBadge';
 export * from './ExpandableList';
 export * from './FilterList';
 export * from './InternalLink';

--- a/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationContent.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/NotarizationContent.tsx
@@ -14,6 +14,9 @@ import {
 } from '../headerMetadataHelper';
 import { useResolveNotarization } from '~/hooks/useResolveNotarization';
 import { NotarizationSummaryView } from './views/NotarizationSummaryView';
+import { LockLifecycleView } from './views/LockLifecycleView';
+import { OwnersView } from './views/OwnersView';
+import { SideBySidePanels } from '~/components/ui/SideBySidePanels';
 import { TransactionsView } from '../common/TransactionsView';
 import { StateView } from './views/StateView';
 import { NotarizationJsonView } from './views/NotarizationJsonView';
@@ -116,6 +119,14 @@ export function NotarizationContent({ objectId }: NotarizationContentProps) {
                     <NotarizationSummaryView
                         objectData={objectResult.data!}
                         notarizationDocument={notarizationDocument}
+                    />
+                    <SideBySidePanels
+                        firstPanel={
+                            <LockLifecycleView
+                                locking={notarizationDocument.immutableMetadata.locking}
+                            />
+                        }
+                        secondPanel={<OwnersView objectId={objectId} />}
                     />
                     <StateView notarization={notarizationDocument} />
                     <NotarizationJsonView notarization={notarizationDocument} />

--- a/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetNotarizationOwnerHistory.ts
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetNotarizationOwnerHistory.ts
@@ -44,7 +44,7 @@ export function useGetNotarizationOwnerHistory(objectId: string) {
     const client = useIotaClient();
     const normalizedId = useMemo(() => normalizeIotaObjectId(objectId), [objectId]);
 
-    const query = useInfiniteQuery<PaginatedTransactionResponse, Error, OwnerEntry[]>({
+    return useInfiniteQuery<PaginatedTransactionResponse, Error, OwnerEntry[]>({
         queryKey: ['get-owner-history', objectId],
         queryFn: async ({ pageParam }) =>
             await client.queryTransactionBlocks({
@@ -79,15 +79,6 @@ export function useGetNotarizationOwnerHistory(objectId: string) {
             return entries;
         },
     });
-
-    return {
-        owners: query.data ?? [],
-        isPending: query.isPending,
-        isError: query.isError,
-        hasNextPage: query.hasNextPage,
-        isFetchingNextPage: query.isFetchingNextPage,
-        fetchNextPage: query.fetchNextPage,
-    };
 }
 
 /**

--- a/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetNotarizationOwnerHistory.ts
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetNotarizationOwnerHistory.ts
@@ -40,7 +40,7 @@ export interface OwnerEntry {
  * @param objectId The object ID to get the owner history for.
  * @returns An object containing the processed list of owners and the state of the infinite query.
  */
-export function useGetOwnerHistory(objectId: string) {
+export function useGetNotarizationOwnerHistory(objectId: string) {
     const client = useIotaClient();
 
     const query = useInfiniteQuery<PaginatedTransactionResponse, Error>({

--- a/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetNotarizationOwnerHistory.ts
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetNotarizationOwnerHistory.ts
@@ -42,8 +42,9 @@ export interface OwnerEntry {
  */
 export function useGetNotarizationOwnerHistory(objectId: string) {
     const client = useIotaClient();
+    const normalizedId = useMemo(() => normalizeIotaObjectId(objectId), [objectId]);
 
-    const query = useInfiniteQuery<PaginatedTransactionResponse, Error>({
+    const query = useInfiniteQuery<PaginatedTransactionResponse, Error, OwnerEntry[]>({
         queryKey: ['get-owner-history', objectId],
         queryFn: async ({ pageParam }) =>
             await client.queryTransactionBlocks({
@@ -61,31 +62,26 @@ export function useGetNotarizationOwnerHistory(objectId: string) {
         staleTime: 10 * 1000,
         retry: false,
         enabled: !!objectId,
-    });
+        select: (data) => {
+            const entries: OwnerEntry[] = [];
+            let lastOwnerAddress: string | null = null;
 
-    const normalizedId = useMemo(() => normalizeIotaObjectId(objectId), [objectId]);
-
-    const owners = useMemo(() => {
-        if (!query.data) return [];
-
-        const entries: OwnerEntry[] = [];
-        let lastOwnerAddress: string | null = null;
-
-        for (const page of query.data.pages) {
-            for (const tx of page.data) {
-                const entry = extractOwnerFromTx(tx, normalizedId, lastOwnerAddress);
-                if (entry) {
-                    entries.push(entry);
-                    lastOwnerAddress = entry.ownerAddress;
+            for (const page of data.pages) {
+                for (const tx of page.data) {
+                    const entry = extractOwnerFromTx(tx, normalizedId, lastOwnerAddress);
+                    if (entry) {
+                        entries.push(entry);
+                        lastOwnerAddress = entry.ownerAddress;
+                    }
                 }
             }
-        }
 
-        return entries;
-    }, [normalizedId, query.data]);
+            return entries;
+        },
+    });
 
     return {
-        owners,
+        owners: query.data ?? [],
         isPending: query.isPending,
         isError: query.isError,
         hasNextPage: query.hasNextPage,

--- a/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetNotarizationOwnerHistory.ts
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetNotarizationOwnerHistory.ts
@@ -120,9 +120,11 @@ function extractOwnerFromTx(
 
     const change = tx.objectChanges?.find(
         (c) =>
+            // filter change types that don't have owner or recipient property
             c.type !== 'published' &&
+            c.type !== 'deleted' &&
+            c.type !== 'wrapped' &&
             c.objectId === normalizedId &&
-            (c.type === 'mutated' || c.type === 'created' || c.type === 'transferred') &&
             c.objectType.includes(NOTARIZATION_MODULE_FRAGMENT),
     );
 
@@ -130,8 +132,8 @@ function extractOwnerFromTx(
 
     const owner: ObjectOwner | undefined =
         change.type === 'transferred'
-            ? change.recipient
-            : change.type === 'mutated' || change.type === 'created'
+            ? change.recipient // new owner
+            : change.type === 'mutated' || change.type === 'created' || change.type === 'unwrapped' // current owner
               ? change.owner
               : undefined;
 

--- a/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetNotarizationOwnerHistory.ts
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetNotarizationOwnerHistory.ts
@@ -140,7 +140,7 @@ function extractOwnerFromTx(
     const ownerType = getOwnerType(owner);
     const ownerAddress = getOwnerAddress(owner);
 
-    // skip tx with not suppported owner and with the same previous address
+    // skip tx with not supported owner and with the same previous address
     if (!ownerAddress || !ownerType || ownerAddress === lastOwnerAddress) return null;
 
     return {

--- a/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetOwnerHistory.ts
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetOwnerHistory.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { useIotaClient } from '@iota/dapp-kit';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { type ObjectOwner, type PaginatedTransactionResponse } from '@iota/iota-sdk/client';
+import { useMemo } from 'react';
+import { getOwnerAddress, getOwnerType } from '../../objectOwnerHelper';
+import { normalizeIotaObjectId } from '@iota/iota-sdk/utils';
+
+const OWNER_HISTORY_LIMIT = 5;
+
+export interface OwnerEntry {
+    ownerAddress: string;
+    ownerType: string;
+    transactionDigest: string;
+    timestampMs: string | null;
+}
+
+/**
+ * Fetches and processes the ownership history of a specified object ID.
+ * It queries for transaction blocks that changed the object and extracts the owner from each relevant transaction.
+ * It ensures that each owner is listed in descending order when the transfer happens, even if they appear in multiple transactions.
+ *
+ * For example if we have the following transactions:
+ * tx 5 - owner B
+ * tx 4 - owner B
+ * tx 3 - owner A
+ * tx 2 - owner A
+ * tx 1 - owner C
+ *
+ * We have the following owner result list:
+ * owner B
+ * owner A
+ * owner C
+ *
+ * @param objectId The object ID to get the owner history for.
+ * @returns An object containing the processed list of owners and the state of the infinite query.
+ */
+export function useGetOwnerHistory(objectId: string) {
+    const client = useIotaClient();
+
+    const query = useInfiniteQuery<PaginatedTransactionResponse, Error>({
+        queryKey: ['get-owner-history', objectId],
+        queryFn: async ({ pageParam }) =>
+            await client.queryTransactionBlocks({
+                filter: { ChangedObject: objectId },
+                cursor: pageParam as string | null,
+                order: 'descending',
+                limit: OWNER_HISTORY_LIMIT,
+                options: {
+                    showObjectChanges: true,
+                    showInput: true,
+                },
+            }),
+        initialPageParam: null,
+        getNextPageParam: ({ hasNextPage, nextCursor }) => (hasNextPage ? nextCursor : null),
+        staleTime: 10 * 1000,
+        retry: false,
+        enabled: !!objectId,
+    });
+
+    const owners = useMemo(() => {
+        if (!query.data) return [];
+
+        const entries: OwnerEntry[] = [];
+        let currentOwnerAddress = null;
+
+        for (const page of query.data.pages) {
+            for (const tx of page.data) {
+                if (tx.errors && tx.errors.length > 0) {
+                    // Skip failed tx
+                    continue;
+                }
+
+                if (!tx.confirmedLocalExecution) {
+                    // NOTE: How to assert finality of a tx?
+                    console.warn(`Transaction ${tx.digest} is not yet locally confirmed.`);
+                }
+
+                const change = tx.objectChanges?.find(
+                    (c) =>
+                        c.type !== 'published' &&
+                        c.objectId === normalizeIotaObjectId(objectId) &&
+                        (c.type === 'mutated' ||
+                            c.type === 'created' ||
+                            c.type === 'transferred') &&
+                        // NOTE: Should I consider the package ID match here?
+                        c.objectType.includes('::notarization::'),
+                );
+
+                if (!change) continue;
+
+                const owner: ObjectOwner | undefined =
+                    change.type === 'transferred'
+                        ? change.recipient
+                        : change.type === 'mutated' || change.type === 'created'
+                          ? change.owner
+                          : undefined;
+
+                const ownerType = getOwnerType(owner);
+                const ownerAddress = getOwnerAddress(owner, objectId);
+
+                if (!ownerAddress || currentOwnerAddress === ownerAddress) continue;
+                currentOwnerAddress = ownerAddress;
+
+                entries.push({
+                    ownerAddress,
+                    ownerType,
+                    transactionDigest: tx.digest,
+                    timestampMs: tx.timestampMs ?? null,
+                });
+            }
+        }
+
+        return entries;
+    }, [query.data, objectId]);
+
+    return {
+        owners,
+        isPending: query.isPending,
+        isError: query.isError,
+        hasNextPage: query.hasNextPage,
+        isFetchingNextPage: query.isFetchingNextPage,
+        fetchNextPage: query.fetchNextPage,
+    };
+}

--- a/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetOwnerHistory.ts
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetOwnerHistory.ts
@@ -74,7 +74,8 @@ export function useGetOwnerHistory(objectId: string) {
                 }
 
                 if (!tx.confirmedLocalExecution) {
-                    // NOTE: How to assert finality of a tx?
+                    // NOTE: For now we are only interested to let a technical user knows why
+                    // the transaction was not considered, because it is not yet confirmed.
                     console.warn(`Transaction ${tx.digest} is not yet locally confirmed.`);
                 }
 
@@ -85,7 +86,10 @@ export function useGetOwnerHistory(objectId: string) {
                         (c.type === 'mutated' ||
                             c.type === 'created' ||
                             c.type === 'transferred') &&
-                        // NOTE: Should I consider the package ID match here?
+                        // NOTE: Because notarization package do not tends to change
+                        // I will not consider it in the match.
+                        // Event in the case a notarization packcage change, the network client
+                        // will provide the correct one
                         c.objectType.includes('::notarization::'),
                 );
 
@@ -114,7 +118,7 @@ export function useGetOwnerHistory(objectId: string) {
         }
 
         return entries;
-    }, [query.data, objectId]);
+    }, [objectId, query.data]);
 
     return {
         owners,

--- a/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetOwnerHistory.ts
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/hooks/useGetOwnerHistory.ts
@@ -9,6 +9,9 @@ import { getOwnerAddress, getOwnerType } from '../../objectOwnerHelper';
 import { normalizeIotaObjectId } from '@iota/iota-sdk/utils';
 
 const OWNER_HISTORY_LIMIT = 5;
+// Assuming the package is correct, because it is served by the client,
+// I'will not including the package in the type to check.
+const NOTARIZATION_MODULE_FRAGMENT = '::notarization::';
 
 export interface OwnerEntry {
     ownerAddress: string;
@@ -60,65 +63,26 @@ export function useGetOwnerHistory(objectId: string) {
         enabled: !!objectId,
     });
 
+    const normalizedId = useMemo(() => normalizeIotaObjectId(objectId), [objectId]);
+
     const owners = useMemo(() => {
         if (!query.data) return [];
 
         const entries: OwnerEntry[] = [];
-        let currentOwnerAddress = null;
+        let lastOwnerAddress: string | null = null;
 
         for (const page of query.data.pages) {
             for (const tx of page.data) {
-                if (tx.errors && tx.errors.length > 0) {
-                    // Skip failed tx
-                    continue;
+                const entry = extractOwnerFromTx(tx, normalizedId, lastOwnerAddress);
+                if (entry) {
+                    entries.push(entry);
+                    lastOwnerAddress = entry.ownerAddress;
                 }
-
-                if (!tx.confirmedLocalExecution) {
-                    // NOTE: For now we are only interested to let a technical user knows why
-                    // the transaction was not considered, because it is not yet confirmed.
-                    console.warn(`Transaction ${tx.digest} is not yet locally confirmed.`);
-                }
-
-                const change = tx.objectChanges?.find(
-                    (c) =>
-                        c.type !== 'published' &&
-                        c.objectId === normalizeIotaObjectId(objectId) &&
-                        (c.type === 'mutated' ||
-                            c.type === 'created' ||
-                            c.type === 'transferred') &&
-                        // NOTE: Because notarization package do not tends to change
-                        // I will not consider it in the match.
-                        // Event in the case a notarization packcage change, the network client
-                        // will provide the correct one
-                        c.objectType.includes('::notarization::'),
-                );
-
-                if (!change) continue;
-
-                const owner: ObjectOwner | undefined =
-                    change.type === 'transferred'
-                        ? change.recipient
-                        : change.type === 'mutated' || change.type === 'created'
-                          ? change.owner
-                          : undefined;
-
-                const ownerType = getOwnerType(owner);
-                const ownerAddress = getOwnerAddress(owner, objectId);
-
-                if (!ownerAddress || currentOwnerAddress === ownerAddress) continue;
-                currentOwnerAddress = ownerAddress;
-
-                entries.push({
-                    ownerAddress,
-                    ownerType,
-                    transactionDigest: tx.digest,
-                    timestampMs: tx.timestampMs ?? null,
-                });
             }
         }
 
         return entries;
-    }, [objectId, query.data]);
+    }, [normalizedId, query.data]);
 
     return {
         owners,
@@ -127,5 +91,60 @@ export function useGetOwnerHistory(objectId: string) {
         hasNextPage: query.hasNextPage,
         isFetchingNextPage: query.isFetchingNextPage,
         fetchNextPage: query.fetchNextPage,
+    };
+}
+
+/**
+ * Extracts ownership information from a transaction block response.
+ * Filters for transactions that successfully mutated, created, or transferred the targeted object,
+ * specifically looking for notarization package changes.
+ *
+ * @param tx - The transaction block response from the paginated network query.
+ * @param normalizedId - The normalized object ID to check against changes in the transaction.
+ * @param lastOwnerAddress - The address of the previously processed owner to prevent duplicate consecutive entries.
+ * @returns A `OwnerEntry` (if valid and not a consecutive duplicate).
+ */
+function extractOwnerFromTx(
+    tx: PaginatedTransactionResponse['data'][number],
+    normalizedId: string,
+    lastOwnerAddress: string | null,
+): OwnerEntry | null {
+    if (tx.errors && tx.errors.length > 0) {
+        // Skip failed tx
+        return null;
+    }
+
+    if (!tx.confirmedLocalExecution) {
+        // Do nothing, but transaction is not yet confirmed.
+    }
+
+    const change = tx.objectChanges?.find(
+        (c) =>
+            c.type !== 'published' &&
+            c.objectId === normalizedId &&
+            (c.type === 'mutated' || c.type === 'created' || c.type === 'transferred') &&
+            c.objectType.includes(NOTARIZATION_MODULE_FRAGMENT),
+    );
+
+    if (!change) return null;
+
+    const owner: ObjectOwner | undefined =
+        change.type === 'transferred'
+            ? change.recipient
+            : change.type === 'mutated' || change.type === 'created'
+              ? change.owner
+              : undefined;
+
+    const ownerType = getOwnerType(owner);
+    const ownerAddress = getOwnerAddress(owner);
+
+    // skip tx with not suppported owner and with the same previous address
+    if (!ownerAddress || !ownerType || ownerAddress === lastOwnerAddress) return null;
+
+    return {
+        ownerAddress,
+        ownerType: ownerType as string,
+        transactionDigest: tx.digest,
+        timestampMs: tx.timestampMs ?? null,
     };
 }

--- a/apps/explorer/src/pages/trust-framework/notarization-result/views/LockLifecycleView.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/views/LockLifecycleView.tsx
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { LockLocked, LockUnlocked, Info } from '@iota/apps-ui-icons';
+import {
+    BadgeType,
+    InfoBox,
+    InfoBoxStyle,
+    InfoBoxType,
+    KeyValueInfo,
+    Title,
+    TitleSize,
+    TooltipPosition,
+} from '@iota/apps-ui-kit';
+import { formatDate } from '@iota/core';
+import { type LockMetadata, type TimeLock } from '@iota/notarization/web';
+import { CollapsibleCard, ErrorBoundary, IconBadge } from '~/components';
+import { useEffect, useState } from 'react';
+
+interface LockLifecycleViewProps {
+    locking: LockMetadata | undefined;
+}
+
+export function LockLifecycleView({ locking }: LockLifecycleViewProps): JSX.Element {
+    if (locking == null) {
+        return (
+            <ErrorBoundary>
+                <div className="flex w-full flex-col gap-sm">
+                    <Title
+                        title="Lock Lifecycle"
+                        tooltipPosition={TooltipPosition.Left}
+                        tooltipText="View the lock lifecycle governing transfer, update, and delete operations on this notarization."
+                    />
+                    <div className="flex flex-col">
+                        <InfoBox
+                            supportingText="No lock configuration found for this notarization."
+                            icon={<Info />}
+                            type={InfoBoxType.Default}
+                            style={InfoBoxStyle.Elevated}
+                        />
+                    </div>
+                </div>
+            </ErrorBoundary>
+        );
+    }
+
+    return (
+        <ErrorBoundary>
+            <div className="flex w-full flex-col gap-sm">
+                <Title
+                    title="Lock Lifecycle"
+                    tooltipPosition={TooltipPosition.Left}
+                    tooltipText="View the lock lifecycle governing transfer, update, and delete operations on this notarization."
+                />
+                <div className="flex flex-col gap-sm">
+                    <LockCard operation={LockOperation.Transfer} timeLock={locking.transferLock} />
+                    <LockCard operation={LockOperation.Update} timeLock={locking.updateLock} />
+                    <LockCard operation={LockOperation.Delete} timeLock={locking.deleteLock} />
+                </div>
+            </div>
+        </ErrorBoundary>
+    );
+}
+
+enum LockOperation {
+    Transfer = 'Transfer',
+    Update = 'Update',
+    Delete = 'Delete',
+}
+
+interface LockCardProps {
+    operation: LockOperation;
+    timeLock: TimeLock;
+}
+
+function LockCard({ operation, timeLock }: LockCardProps): JSX.Element {
+    const { badgeType, badgeLabel, icon } = getLockBadgeStyle(timeLock);
+
+    return (
+        <CollapsibleCard
+            collapsible
+            title={`${operation} Lock`}
+            titleSize={TitleSize.Small}
+            supportingTitleElement={
+                <div className="ml-1 flex">
+                    <IconBadge label={badgeLabel} type={badgeType} icon={icon} />
+                </div>
+            }
+        >
+            <div className="flex flex-col gap-4 py-sm--rs">
+                <LockType operation={operation} timeLock={timeLock} />
+                <LockExpiration timeLock={timeLock} />
+            </div>
+        </CollapsibleCard>
+    );
+}
+
+interface LockTypeProps {
+    operation: LockOperation;
+    timeLock: TimeLock;
+}
+
+function LockType({ operation, timeLock }: LockTypeProps): JSX.Element {
+    return (
+        <div className="flex flex-wrap px-md--rs">
+            <KeyValueInfo
+                keyText="Lock Type"
+                value={timeLock.type}
+                fullwidth
+                tooltipPosition={TooltipPosition.Left}
+                tooltipText={getLockTypeTooltip(operation, timeLock)}
+            />
+        </div>
+    );
+}
+
+interface LockExpirationProps {
+    timeLock: TimeLock;
+}
+
+function LockExpiration({ timeLock }: LockExpirationProps): JSX.Element | null {
+    if (timeLock.type !== 'UnlockAt') {
+        return null;
+    }
+
+    const unlockTimestampSec = Number(timeLock.args);
+    const unlockDate = new Date(unlockTimestampSec * 1000);
+    const formattedDate = formatDate(unlockDate, ['year', 'month', 'day', 'hour', 'minute']);
+    const countdown = useCountdown(unlockDate);
+
+    return (
+        <div className="flex flex-wrap px-md--rs">
+            <KeyValueInfo
+                keyText="Unlocks at"
+                value={`${formattedDate} (${countdown})`}
+                fullwidth
+                tooltipPosition={TooltipPosition.Left}
+                tooltipText={`This lock expires on ${formattedDate}. After expiration the operation becomes available.`}
+            />
+        </div>
+    );
+}
+
+function useCountdown(targetDate: Date): string {
+    const [now, setNow] = useState(() => Date.now());
+
+    useEffect(() => {
+        const interval = setInterval(() => setNow(Date.now()), 60_000);
+        return () => clearInterval(interval);
+    }, []);
+
+    const diffMs = targetDate.getTime() - now;
+    if (diffMs <= 0) {
+        return 'Expired';
+    }
+
+    const totalMinutes = Math.floor(diffMs / 60_000);
+    const minutes = totalMinutes % 60;
+    const totalHours = Math.floor(totalMinutes / 60);
+    const hours = totalHours % 24;
+    const days = Math.floor(totalHours / 24);
+
+    const parts: string[] = [];
+    if (days > 0) parts.push(`${days}d`);
+    if (hours > 0) parts.push(`${hours}h`);
+    if (minutes > 0) parts.push(`${minutes}m`);
+
+    return parts.length > 0 ? parts.join(' ') + ' remaining' : 'Less than a minute';
+}
+
+function getLockTypeTooltip(operation: LockOperation, timeLock: TimeLock): string {
+    const op = operation.toLowerCase();
+    switch (timeLock.type) {
+        case 'None':
+            return `The ${op} operation is not locked and can be performed at any time.`;
+        case 'UnlockAt':
+            return `The ${op} operation is time-locked and will become available after the expiration date.`;
+        case 'UntilDestroyed':
+            return `The ${op} operation is permanently locked and cannot be performed.`;
+    }
+}
+
+enum LockStatus {
+    Unlocked = 'Unlocked',
+    TimeLocked = 'Time Locked',
+    PermanentlyLocked = 'Permanently Locked',
+}
+
+function getLockBadgeStyle(timeLock: TimeLock): {
+    badgeType: BadgeType;
+    badgeLabel: LockStatus;
+    icon: JSX.Element;
+} {
+    switch (timeLock.type) {
+        case 'None':
+            return {
+                badgeType: BadgeType.PrimarySoft,
+                badgeLabel: LockStatus.Unlocked,
+                icon: <LockUnlocked className="h-4 w-4" />,
+            };
+        case 'UnlockAt':
+            if (isTimeLockExpired(timeLock)) {
+                return {
+                    badgeType: BadgeType.PrimarySoft,
+                    badgeLabel: LockStatus.Unlocked,
+                    icon: <LockUnlocked className="h-4 w-4" />,
+                };
+            }
+            return {
+                badgeType: BadgeType.Neutral,
+                badgeLabel: LockStatus.TimeLocked,
+                icon: <LockLocked className="h-4 w-4" />,
+            };
+        case 'UntilDestroyed':
+            return {
+                badgeType: BadgeType.Neutral,
+                badgeLabel: LockStatus.PermanentlyLocked,
+                icon: <LockLocked className="h-4 w-4" />,
+            };
+    }
+}
+
+function isTimeLockExpired(timeLock: TimeLock): boolean {
+    if (timeLock.type !== 'UnlockAt') return false;
+    const unlockTimestampSec = Number(timeLock.args);
+    return Date.now() >= unlockTimestampSec * 1000;
+}

--- a/apps/explorer/src/pages/trust-framework/notarization-result/views/OwnersView.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/views/OwnersView.tsx
@@ -27,7 +27,10 @@ import {
     ObjectLink,
     TransactionLink,
 } from '~/components';
-import { useGetOwnerHistory, type OwnerEntry } from '../hooks/useGetOwnerHistory';
+import {
+    useGetNotarizationOwnerHistory,
+    type OwnerEntry,
+} from '../hooks/useGetNotarizationOwnerHistory';
 
 enum OwnerLabel {
     Current = 'Current',
@@ -40,7 +43,7 @@ interface OwnersViewProps {
 
 export function OwnersView({ objectId }: OwnersViewProps): JSX.Element {
     const { owners, isPending, isError, hasNextPage, isFetchingNextPage, fetchNextPage } =
-        useGetOwnerHistory(objectId);
+        useGetNotarizationOwnerHistory(objectId);
 
     return (
         <ErrorBoundary>

--- a/apps/explorer/src/pages/trust-framework/notarization-result/views/OwnersView.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/views/OwnersView.tsx
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    Badge,
+    BadgeType,
+    Button,
+    ButtonSize,
+    ButtonType,
+    InfoBox,
+    InfoBoxStyle,
+    InfoBoxType,
+    KeyValueInfo,
+    LoadingIndicator,
+    Title,
+    TitleSize,
+    TooltipPosition,
+} from '@iota/apps-ui-kit';
+import { formatDate } from '@iota/core';
+import { formatDigest } from '@iota/iota-sdk/utils';
+import { Warning, Person } from '@iota/apps-ui-icons';
+import {
+    AddressLink,
+    CollapsibleCard,
+    ErrorBoundary,
+    IconBadge,
+    ObjectLink,
+    TransactionLink,
+} from '~/components';
+import { useGetOwnerHistory, type OwnerEntry } from '../hooks/useGetOwnerHistory';
+
+enum OwnerLabel {
+    Current = 'Current',
+    Previous = 'Previous',
+}
+
+interface OwnersViewProps {
+    objectId: string;
+}
+
+export function OwnersView({ objectId }: OwnersViewProps): JSX.Element {
+    const { owners, isPending, isError, hasNextPage, isFetchingNextPage, fetchNextPage } =
+        useGetOwnerHistory(objectId);
+
+    return (
+        <ErrorBoundary>
+            <div className="flex w-full flex-col gap-sm">
+                <Title
+                    title="Owners History"
+                    tooltipPosition={TooltipPosition.Left}
+                    tooltipText="The history of addresses that have owned this notarization object, ordered from most recent to oldest."
+                />
+                <div className="flex flex-col gap-sm">
+                    {isPending && (
+                        <div className="flex justify-center">
+                            <LoadingIndicator size="w-6 h-6" text="Loading owners..." />
+                        </div>
+                    )}
+                    {isError && (
+                        <InfoBox
+                            title="Error Fetching Owners"
+                            supportingText={`Could not fetch owner history for object ${objectId} on the current network.`}
+                            icon={<Warning />}
+                            type={InfoBoxType.Error}
+                            style={InfoBoxStyle.Elevated}
+                        />
+                    )}
+                    {owners.map((owner, index) => (
+                        <OwnerCard
+                            key={owner.transactionDigest}
+                            owner={owner}
+                            label={index === 0 ? OwnerLabel.Current : OwnerLabel.Previous}
+                        />
+                    ))}
+                    {hasNextPage && (
+                        <div className="flex justify-center">
+                            <Button
+                                size={ButtonSize.Small}
+                                type={ButtonType.Ghost}
+                                text={isFetchingNextPage ? 'Loading...' : 'Identify More Owners'}
+                                disabled={isFetchingNextPage}
+                                onClick={() => fetchNextPage()}
+                            />
+                        </div>
+                    )}
+                </div>
+            </div>
+        </ErrorBoundary>
+    );
+}
+
+interface OwnerCardProps {
+    owner: OwnerEntry;
+    label: OwnerLabel;
+}
+
+function OwnerCard({ owner, label }: OwnerCardProps): JSX.Element {
+    const badgeType = label === OwnerLabel.Current ? BadgeType.PrimarySoft : BadgeType.Neutral;
+    const timestamp = owner.timestampMs
+        ? formatDate(new Date(Number(owner.timestampMs)), [
+              'year',
+              'month',
+              'day',
+              'hour',
+              'minute',
+          ])
+        : null;
+
+    return (
+        <CollapsibleCard
+            collapsible
+            title="Owner"
+            titleSize={TitleSize.Small}
+            supportingTitleElement={
+                <div className="ml-1 flex gap-x-1">
+                    <Badge label={owner.ownerType} type={BadgeType.Neutral} />
+                    <IconBadge label={label} type={badgeType} icon={<Person />} />
+                </div>
+            }
+            footer={<OwnerCardFooter owner={owner} />}
+        >
+            <div className="flex flex-col gap-4 py-sm--rs">
+                <OwnerType owner={owner} />
+                <OwnershipTransactionLink owner={owner} />
+                <TransactionDate timestamp={timestamp} />
+            </div>
+        </CollapsibleCard>
+    );
+}
+
+function OwnerType({ owner }: { owner: OwnerEntry }) {
+    return (
+        <div className="flex flex-wrap px-md--rs">
+            <KeyValueInfo
+                keyText="Type"
+                value={owner.ownerType}
+                fullwidth
+                tooltipPosition={TooltipPosition.Left}
+                tooltipText="The ownership type: address-owned, object-owned, or shared."
+            />
+        </div>
+    );
+}
+
+function OwnerAddress({ owner }: { owner: OwnerEntry }) {
+    return (
+        <div className="flex flex-wrap px-md--rs">
+            <KeyValueInfo
+                keyText="Owner"
+                value={
+                    <OwnerAddressDisplay
+                        ownerType={owner.ownerType}
+                        ownerAddress={owner.ownerAddress}
+                    />
+                }
+                fullwidth
+                tooltipPosition={TooltipPosition.Left}
+                tooltipText="The address that owns or owned this notarization object."
+            />
+        </div>
+    );
+}
+
+interface OwnerAddressDisplayProps {
+    ownerType: string;
+    ownerAddress: string;
+}
+
+function OwnerAddressDisplay({ ownerType, ownerAddress }: OwnerAddressDisplayProps): JSX.Element {
+    if (ownerType === 'AddressOwner') {
+        return (
+            <AddressLink
+                address={ownerAddress}
+                copyText={ownerAddress}
+                className="[&>div]:max-w-[200px] [&>div]:truncate"
+                display="block"
+            />
+        );
+    }
+
+    if (ownerType === 'ObjectOwner') {
+        return <ObjectLink objectId={ownerAddress} copyText={ownerAddress} />;
+    }
+
+    if (ownerType === 'Shared') {
+        return <ObjectLink objectId={ownerAddress} label="Shared" showAddressAlias={false} />;
+    }
+
+    return <span>{ownerAddress}</span>;
+}
+
+interface OwnerCardFooterProps {
+    owner: OwnerEntry;
+}
+
+function OwnerCardFooter({ owner }: OwnerCardFooterProps): JSX.Element {
+    return (
+        <div className="flex flex-col gap-4 py-sm--rs">
+            <OwnerAddress owner={owner} />
+        </div>
+    );
+}
+
+function TransactionDate({ timestamp }: { timestamp: string | null }) {
+    return (
+        timestamp && (
+            <div className="flex flex-wrap px-md--rs">
+                <KeyValueInfo
+                    keyText="Date"
+                    value={timestamp}
+                    fullwidth
+                    tooltipPosition={TooltipPosition.Left}
+                    tooltipText="When this ownership change occurred."
+                />
+            </div>
+        )
+    );
+}
+
+function OwnershipTransactionLink({ owner }: { owner: OwnerEntry }) {
+    return (
+        <div className="flex flex-wrap px-md--rs">
+            <KeyValueInfo
+                keyText="Transaction"
+                value={
+                    <TransactionLink digest={owner.transactionDigest}>
+                        {formatDigest(owner.transactionDigest)}
+                    </TransactionLink>
+                }
+                fullwidth
+                tooltipPosition={TooltipPosition.Left}
+                tooltipText="The transaction that assigned this owner to the notarization object."
+            />
+        </div>
+    );
+}

--- a/apps/explorer/src/pages/trust-framework/notarization-result/views/OwnersView.tsx
+++ b/apps/explorer/src/pages/trust-framework/notarization-result/views/OwnersView.tsx
@@ -42,8 +42,14 @@ interface OwnersViewProps {
 }
 
 export function OwnersView({ objectId }: OwnersViewProps): JSX.Element {
-    const { owners, isPending, isError, hasNextPage, isFetchingNextPage, fetchNextPage } =
-        useGetNotarizationOwnerHistory(objectId);
+    const {
+        data: owners,
+        isPending,
+        isError,
+        hasNextPage,
+        isFetchingNextPage,
+        fetchNextPage,
+    } = useGetNotarizationOwnerHistory(objectId);
 
     return (
         <ErrorBoundary>
@@ -68,7 +74,7 @@ export function OwnersView({ objectId }: OwnersViewProps): JSX.Element {
                             style={InfoBoxStyle.Elevated}
                         />
                     )}
-                    {owners.map((owner, index) => (
+                    {owners?.map((owner, index) => (
                         <OwnerCard
                             key={owner.transactionDigest}
                             owner={owner}


### PR DESCRIPTION
# Description of change

**Problem:** Users viewing a Notarization object in the explorer currently cannot see its ownership history or the lock lifecycle (Transfer/Update/Delete locks) governing it. This information is critical for transparency and auditing trust-framework activities.

**Solution:**
- **Lock Lifecycle:** Added `LockLifecycleView` to interpret and display the `LockMetadata` status (Unlocked, Time Locked, Permanently Locked) and visualize expiration timers.
- **Ownership Reconstruction:** Added `OwnersView` and `useGetNotarizationOwnerHistory`. Since L1 doesn't persist historical ownership natively, this hook reconstructs the history by paginating through transaction blocks that changed the object and identifying the recipient/owner in `objectChanges`.
- **UI Components:** Introduced `IconBadge` to extend badges with an icon (candidate to be moved to `ui-kit` later).

**Impact:** Full visibility into the lifecycle and ownership of trust-framework notarization objects, empowering users to trace object provenance.

*(Insert screenshots of LockLifecycleView and OwnersView here!)*

## Links to any relevant issues
N/A

## How the change has been tested
Manually tested on `testnet`.

**Reviewer Instructions:**
1. Run the explorer locally.
2. Ensure you have the notarization package configured (`VITE_IOTA_NOTARIZATION_PKG_ID` in `.env`) or use a network with a known package.
3. Navigate to `/notarization/0x23be2a1a617f0af6830ffe328c357df7c73de25b2013eef362e8cc09f9df9f57?network=testnet`
4. Verify that the "Lock Lifecycle" and "Owners History" panels render correctly in the side-by-side view.

Access the Preview at https://rebased-explorer-git-feat-notarization-search-iota1.vercel.app/notarization/0x23be2a1a617f0af6830ffe328c357df7c73de25b2013eef362e8cc09f9df9f57?network=testnet to see a Dynamic notarization object.

Refer to https://github.com/iotaledger/ts-packages/pull/138#issue-4315699223 at Test on testnet section to get more notarization objects IDs.

## Expected UI
<img width="3162" height="1926" alt="image" src="https://github.com/user-attachments/assets/d121dbc3-2439-4f8b-9dbe-81301cbc8f59" />
