### PR TITLE
feat(explorer): enable notarization search

### DIFF
--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -20,16 +20,37 @@ import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import { useNetwork } from './useNetwork';
 import { type IdentityClientReadOnly } from '@iota/identity-wasm/web';
 import { useFeatureIsOn } from '@iota/apps-backend-client';
+import { type NotarizationClientReadOnly } from '@iota/notarization/web';
 import {
     tryGenerateDidFromObjectId,
     tryDIDParse,
     tryEncodeDidToUrl,
 } from '~/lib/utils/trust-framework/client';
-import { useIdentityClient } from '~/contexts';
+import { useIdentityClient, useNotarizationClient } from '~/contexts';
 
 const isGenesisLibAddress = (value: string): boolean => /^(0x|0X)0{0,39}[12]$/.test(value);
 
 type Results = { id: string; label: string; type: string }[];
+
+const getResultsForNotarization = async (
+    notarizationClient: NotarizationClientReadOnly | null,
+    isNotarizationEnabled: boolean,
+    query: string,
+): Promise<Results | null> => {
+    if (notarizationClient == null) return null; // client not available
+    if (!isNotarizationEnabled) return null; // feature flag disabled
+
+    const notarizationChain = await notarizationClient.getNotarizationById(query);
+    if (!notarizationChain) return null;
+
+    return [
+        {
+            id: notarizationChain.id,
+            label: notarizationChain.id,
+            type: 'notarization',
+        },
+    ];
+};
 
 const getResultsForDid = async (
     identityClient: IdentityClientReadOnly | null,
@@ -238,12 +259,14 @@ const getResultsForValidatorByPoolIdOrIotaAddress = async (
 export function useSearch(query: string): UseQueryResult<Results, Error> {
     const client = useIotaClient();
     const identityClient = useIdentityClient();
+    const notarizationClient = useNotarizationClient();
     const { data: systemStateSummary } = useIotaClientQuery('getLatestIotaSystemState');
     const [networkId] = useNetwork();
     const network = getNetwork(networkId).id;
 
     const isNamesEnabled = useFeatureEnabledByNetwork(Feature.IotaNames, network);
     const isTFIdentityEnabled = useFeatureIsOn(Feature.ExplorerTFIdentity as string);
+    const isTFNotarizationEnabled = useFeatureIsOn(Feature.ExplorerTFNotarization as string);
     const { iotaNamesClient } = useIotaNamesClient();
 
     return useQuery<Results, Error>({
@@ -257,6 +280,7 @@ export function useSearch(query: string): UseQueryResult<Results, Error> {
                     getResultsForEpoch(client, query),
                     getResultsForAddress(client, query, isNamesEnabled, iotaNamesClient),
                     getResultsForDid(identityClient, isTFIdentityEnabled, query),
+                    getResultsForNotarization(notarizationClient, isTFNotarizationEnabled, query),
                     getResultsForObject(client, query),
                     getResultsForValidatorByPoolIdOrIotaAddress(systemStateSummary || null, query),
                 ])


### PR DESCRIPTION
# Description of change

This PR enables users to search for **Notarization** objects directly from the Explorer search bar. This is a key component of the **Trust Framework (TF)** feature set.

### Key Changes:
- **New Search Provider**: Implemented `getResultsForNotarization` to query the Notarization chain by ID.
- **Hook Integration**: Added the notarization lookup to the `useSearch` parallel query execution.
- **Feature Guarding**: The lookup is conditionally executed based on the `ExplorerTFNotarization` feature flag.

## Links to any relevant issues

N/A

## How the change has been tested

- **Manual Verification**: Entered valid Notarization IDs in the search bar and confirmed the "notarization" result type is returned and navigable.
- **Flag Testing**: Confirmed that search functionality remains unaffected and notarization results are omitted when the `ExplorerTFNotarization` flag is disabled.

Access the Preview at https://rebased-explorer-git-feat-notarization-lock-owner-iota1.vercel.app/ and look for 0x23be2a1a617f0af6830ffe328c357df7c73de25b2013eef362e8cc09f9df9f57 to see a Notarization suggestion in the search bar result.

Refer to https://github.com/iotaledger/ts-packages/pull/138#issue-4315699223 at Test on testnet section to get more notarization objects IDs.

## Expected UI
<img width="3114" height="792" alt="image" src="https://github.com/user-attachments/assets/f3c89e80-7218-4a81-9caf-0ace56006990" />
