### PR TITLE
refactor(explorer): did search to avoid panic message

### DIFF
--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -21,12 +21,7 @@ import { useNetwork } from './useNetwork';
 import { type IdentityClientReadOnly } from '@iota/identity-wasm/web';
 import { useFeatureIsOn } from '@iota/apps-backend-client';
 import { type NotarizationClientReadOnly } from '@iota/notarization/web';
-import {
-    tryGenerateDidFromObjectId,
-    tryDIDParse,
-    tryEncodeDidToUrl,
-} from '~/lib/utils/trust-framework/client';
-import { useFeatureIsOn } from '@growthbook/growthbook-react';
+import { tryDIDParse, tryEncodeDidToUrl } from '~/lib/utils/trust-framework/client';
 import { useIdentityClient, useNotarizationClient } from '~/contexts';
 
 const isGenesisLibAddress = (value: string): boolean => /^(0x|0X)0{0,39}[12]$/.test(value);

--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -26,6 +26,7 @@ import {
     tryDIDParse,
     tryEncodeDidToUrl,
 } from '~/lib/utils/trust-framework/client';
+import { useFeatureIsOn } from '@growthbook/growthbook-react';
 import { useIdentityClient, useNotarizationClient } from '~/contexts';
 
 const isGenesisLibAddress = (value: string): boolean => /^(0x|0X)0{0,39}[12]$/.test(value);
@@ -60,11 +61,23 @@ const getResultsForDid = async (
     if (identityClient == null) return null; // client not available
     if (!isIdentityEnabled) return null; // feature flag disabled
 
+    let didDocument = null;
     const didParsed = await tryDIDParse(query);
-    const did = didParsed ?? (await tryGenerateDidFromObjectId(query, identityClient.network()));
-    if (did == null) return null; // either invalid parsing or invalid objectId
 
-    const didDocument = await identityClient.resolveDid(did!);
+    try {
+        if (didParsed == null) {
+            const identity = await identityClient.getIdentity(query);
+            didDocument = identity.toFullFledged()?.didDocument();
+        } else {
+            didDocument = await identityClient.resolveDid(didParsed);
+        }
+    } catch {
+        // DO NOTHING! We are not interested in this error because the consequence
+        // for it to fail is only not show a selection option in the search result
+    }
+
+    if (didDocument == null) return null; // Nothing to show
+
     const didUrlEncoded = await tryEncodeDidToUrl(didDocument.id());
     if (didUrlEncoded == null) {
         throw new Error(

--- a/apps/explorer/src/lib/utils/trust-framework/client.ts
+++ b/apps/explorer/src/lib/utils/trust-framework/client.ts
@@ -5,7 +5,6 @@ import * as identity from '@iota/identity-wasm/web';
 import identityWasmUrl from '@iota/identity-wasm/web/identity_wasm_bg.wasm?url';
 import * as notarization from '@iota/notarization/web';
 import notarizationWasmUrl from '@iota/notarization/web/notarization_wasm_bg.wasm?url';
-import { isValidIotaObjectId } from '@iota/iota-sdk/utils';
 import { type IotaClient, Network } from '@iota/iota-sdk/client';
 import {
     DID_PROTOCOL_SEGMENT_SYMBOL,
@@ -100,24 +99,6 @@ export async function tryDIDParse(didCandidate: string): Promise<identity.IotaDI
     try {
         await initIdentityWasmWeb();
         return identity.IotaDID.parse(didCandidate);
-    } catch {
-        return null;
-    }
-}
-
-/**
- * Try generate an IotaDID from ObjectId and Network and return the generated did,
- * otherwise return null if not possible to generate by any reason.
- */
-export async function tryGenerateDidFromObjectId(
-    objectId: string,
-    network: string,
-): Promise<identity.IotaDID | null> {
-    try {
-        if (!isValidIotaObjectId(objectId)) return null;
-
-        await initIdentityWasmWeb();
-        return identity.IotaDID.fromAliasId(objectId, network);
     } catch {
         return null;
     }


### PR DESCRIPTION
# Description of change

This PR resolves a console "panic"/error that occurs during search when a generic Object ID is incorrectly processed as a Decentralized Identifier (DID).

### Problem
Previously, when a user searched for a standard Object ID, `useSearch` would attempt to forcefully generate a DID from it (`IotaDID.fromAliasId`) and then resolve it. If the Object ID did not correspond to a valid Identity, the underlying `identity-wasm` client would throw a severe console error/panic, creating noise and potential instability.

### Solution
- **API Swap**: We now use `identityClient.getIdentity(query)` when the query is an Object ID. This API is designed to safely check for an Identity associated with the Object ID without throwing panics if one doesn't exist.
- **Cleanup**: Removed the now-obsolete `tryGenerateDidFromObjectId` utility.
- **Graceful Degradation**: Added an explicit `catch` block around the resolution. If the identity lookup fails (e.g., the object is just a coin, not an identity), we swallow the error and simply return `null` so the search UI gracefully omits the DID option without breaking other concurrent search results.

## Links to any relevant issues

N/A

## How the change has been tested

- **Manual Verification**: Searched for a standard non-identity Object ID and confirmed no panic/error is printed to the console.
- **DID Verification**: Searched for a valid DID string and confirmed the DID search result still resolves correctly.

Search an Identity `0xdc704ab63984d5763576c12ce5f62fe735766bc1fc9892a5e2a7be777a9af897` and expect to see no panic console.

Search a Notification `0x23be2a1a617f0af6830ffe328c357df7c73de25b2013eef362e8cc09f9df9f57` and expect to see no panic console either.