### PR TITLE
chore(ci): Skip build CI inside its own workflow

### DIFF
--- a/.github/workflows/_build_lint_test.yml
+++ b/.github/workflows/_build_lint_test.yml
@@ -2,7 +2,16 @@ name: TS Lint, Build, and Test
 
 on:
   workflow_dispatch:
+    inputs:
+      isAffected:
+        description: Whether any package covered by this workflow was changed
+        type: boolean
+        default: true
   workflow_call:
+    inputs:
+      isAffected:
+        type: boolean
+        required: true
     secrets:
       EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK:
         required: true
@@ -16,6 +25,7 @@ concurrency:
 jobs:
   build:
     name: Lint, Build, and Test
+    if: inputs.isAffected
     runs-on: ubuntu-latest
     env:
       VITE_EVM_BRIDGE_DEFAULT_NETWORK: ${{ secrets.EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK }}

--- a/.github/workflows/turbo_hierarchy.yml
+++ b/.github/workflows/turbo_hierarchy.yml
@@ -39,25 +39,11 @@ jobs:
 
 
   build:
-    if: >-
-      !cancelled() && !failure()
-      && (
-        needs.diff.outputs.isExplorer == 'true'
-        || needs.diff.outputs.isTypescriptSDK == 'true'
-        || needs.diff.outputs.isWallet == 'true'
-        || needs.diff.outputs.isWalletDashboard == 'true'
-        || needs.diff.outputs.isEvmBridge == 'true'
-        || needs.diff.outputs.isNamesSDK == 'true'
-        || needs.diff.outputs.isNamesDapp == 'true'
-        || needs.diff.outputs.isNamesDisplay == 'true'
-      )
-      && (
-        github.ref_name == 'develop'
-        || github.event.pull_request.draft == false
-        || contains(github.event.pull_request.body, '[run-ci]')
-      )
+    if: (!cancelled() && !failure() && (github.ref_name == 'develop' || github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     needs: diff
     uses: ./.github/workflows/_build_lint_test.yml
+    with:
+      isAffected: ${{ needs.diff.outputs.isExplorer == 'true' || needs.diff.outputs.isTypescriptSDK == 'true' || needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isWalletDashboard == 'true' || needs.diff.outputs.isEvmBridge == 'true' || needs.diff.outputs.isNamesSDK == 'true' || needs.diff.outputs.isNamesDapp == 'true' || needs.diff.outputs.isNamesDisplay == 'true' }}
     secrets:
       EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK: ${{ secrets.EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK }}
       EVM_BRIDGE_CONFIG: ${{ secrets.EVM_BRIDGE_CONFIG }}


### PR DESCRIPTION
Just like e2e.yml does. This way the required check on GitHub works properly.