### PR TITLE
feat(names): add to calendar

### DIFF
--- a/apps/names/src/components/dialogs/AddToCalendarDialog.tsx
+++ b/apps/names/src/components/dialogs/AddToCalendarDialog.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 'use client';

--- a/apps/names/src/components/dialogs/AddToCalendarDialog.tsx
+++ b/apps/names/src/components/dialogs/AddToCalendarDialog.tsx
@@ -1,0 +1,136 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+'use client';
+
+import { Export, Globe } from '@iota/apps-ui-icons';
+import { Dialog, DialogBody, DialogContent, DialogPosition, Header } from '@iota/apps-ui-kit';
+import { normalizeIotaName } from '@iota/iota-names-sdk';
+
+import { formatDate } from '@/lib/utils/format/formatDate';
+import { type CalendarEvent, google, ics } from '@/lib/utils/calendar';
+
+interface AddToCalendarDialogProps {
+    name: string;
+    expirationDate: Date;
+    setOpen: (bool: boolean) => void;
+}
+
+function at9am(date: Date): Date {
+    const d = new Date(date);
+    d.setHours(9, 0, 0, 0);
+    return d;
+}
+
+function buildEvent(name: string, expirationDate: Date): CalendarEvent {
+    const displayName = normalizeIotaName(name);
+
+    const oneMonthBefore = new Date(expirationDate);
+    oneMonthBefore.setMonth(oneMonthBefore.getMonth() - 1);
+
+    const oneDayBefore = new Date(expirationDate);
+    oneDayBefore.setDate(oneDayBefore.getDate() - 1);
+
+    return {
+        title: `${displayName} – Renewal Reminder`,
+        description: `Your IOTA name ${displayName} expires on ${formatDate(expirationDate)}. Remember to renew it at iotanames.com.`,
+        date: expirationDate,
+        alerts: [
+            {
+                triggerAt: at9am(oneMonthBefore),
+                description: `1 month until ${displayName} expires`,
+            },
+            { triggerAt: at9am(oneDayBefore), description: `1 day until ${displayName} expires` },
+            { triggerAt: at9am(expirationDate), description: `${displayName} expires today` },
+        ],
+    };
+}
+
+function downloadIcsFile(name: string, content: string): void {
+    const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${normalizeIotaName(name)}-renewal.ics`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
+
+interface CalendarOptionProps {
+    icon: React.ReactNode;
+    title: string;
+    description: string;
+    onClick: () => void;
+}
+
+function CalendarOption({ icon, title, description, onClick }: CalendarOptionProps) {
+    return (
+        <button
+            onClick={onClick}
+            className="flex items-start gap-md w-full rounded-xl bg-names-neutral-12 px-md py-sm hover:bg-names-neutral-20 transition-colors cursor-pointer text-left"
+        >
+            <span className="[&_svg]:h-6 [&_svg]:w-6 text-names-neutral-60 mt-0.5 shrink-0">
+                {icon}
+            </span>
+            <div className="flex flex-col gap-xxs">
+                <span className="text-body-lg text-names-neutral-92">{title}</span>
+                <span className="text-body-sm text-names-neutral-60">{description}</span>
+            </div>
+        </button>
+    );
+}
+
+export function AddToCalendarDialog({ name, expirationDate, setOpen }: AddToCalendarDialogProps) {
+    function handleClose() {
+        setOpen(false);
+    }
+
+    function handleGoogleCalendar() {
+        const event = buildEvent(name, expirationDate);
+        window.open(google(event), '_blank', 'noopener noreferrer');
+        handleClose();
+    }
+
+    function handleDownloadIcs() {
+        const event = buildEvent(name, expirationDate);
+        downloadIcsFile(name, ics(event));
+        handleClose();
+    }
+
+    return (
+        <Dialog open onOpenChange={setOpen}>
+            <DialogContent isFixedPosition position={DialogPosition.Right}>
+                <Header title="Add to Calendar" onClose={handleClose} />
+                <DialogBody>
+                    <div className="flex flex-col gap-md">
+                        <p className="text-body-md text-names-neutral-60">
+                            Set a reminder for{' '}
+                            <span className="text-names-neutral-92">{normalizeIotaName(name)}</span>{' '}
+                            expiring on{' '}
+                            <span className="text-names-neutral-92">
+                                {formatDate(expirationDate)}
+                            </span>
+                            .
+                        </p>
+                        <div className="flex flex-col gap-xs">
+                            <CalendarOption
+                                icon={<Globe />}
+                                title="Google Calendar"
+                                description="Opens Google Calendar to create an event. Add reminders manually after the event is created."
+                                onClick={handleGoogleCalendar}
+                            />
+                            <CalendarOption
+                                icon={<Export />}
+                                title="Download .ics"
+                                description="Downloads a calendar file compatible with any app. Includes reminders at 09:00 on the day, 1 day before, and 1 month before."
+                                onClick={handleDownloadIcs}
+                            />
+                        </div>
+                    </div>
+                </DialogBody>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/names/src/components/dialogs/AddToCalendarDialog.tsx
+++ b/apps/names/src/components/dialogs/AddToCalendarDialog.tsx
@@ -8,42 +8,12 @@ import { Dialog, DialogBody, DialogContent, DialogPosition, Header } from '@iota
 import { normalizeIotaName } from '@iota/iota-names-sdk';
 
 import { formatDate } from '@/lib/utils/format/formatDate';
-import { type CalendarEvent, google, ics } from '@/lib/utils/calendar';
+import { buildEvent, google, ics } from '@/lib/utils/calendar';
 
 interface AddToCalendarDialogProps {
     name: string;
     expirationDate: Date;
     setOpen: (bool: boolean) => void;
-}
-
-function at9am(date: Date): Date {
-    const d = new Date(date);
-    d.setHours(9, 0, 0, 0);
-    return d;
-}
-
-function buildEvent(name: string, expirationDate: Date): CalendarEvent {
-    const displayName = normalizeIotaName(name);
-
-    const oneMonthBefore = new Date(expirationDate);
-    oneMonthBefore.setMonth(oneMonthBefore.getMonth() - 1);
-
-    const oneDayBefore = new Date(expirationDate);
-    oneDayBefore.setDate(oneDayBefore.getDate() - 1);
-
-    return {
-        title: `${displayName} – Renewal Reminder`,
-        description: `Your IOTA name ${displayName} expires on ${formatDate(expirationDate)}. Remember to renew it at iotanames.com.`,
-        date: expirationDate,
-        alerts: [
-            {
-                triggerAt: at9am(oneMonthBefore),
-                description: `1 month until ${displayName} expires`,
-            },
-            { triggerAt: at9am(oneDayBefore), description: `1 day until ${displayName} expires` },
-            { triggerAt: at9am(expirationDate), description: `${displayName} expires today` },
-        ],
-    };
 }
 
 function downloadIcsFile(name: string, content: string): void {
@@ -116,13 +86,13 @@ export function AddToCalendarDialog({ name, expirationDate, setOpen }: AddToCale
                             <CalendarOption
                                 icon={<Globe />}
                                 title="Google Calendar"
-                                description="Opens Google Calendar to create an event. We recommend adding reminders for 1 month and 1 day before the expiry date."
+                                description="Opens Google Calendar to create an event. Note: automatic reminders are not supported, you will need to add them manually."
                                 onClick={handleGoogleCalendar}
                             />
                             <CalendarOption
                                 icon={<Export />}
                                 title="Download .ics"
-                                description="Downloads a calendar file compatible with any app. Includes reminders at 09:00 on the expiry day, 1 day before, and 1 month before."
+                                description="Downloads a calendar file compatible with any app. Includes reminders at 09:00 on the expiry day, 1 day before, 1 week before, and 1 month before."
                                 onClick={handleDownloadIcs}
                             />
                         </div>

--- a/apps/names/src/components/dialogs/AddToCalendarDialog.tsx
+++ b/apps/names/src/components/dialogs/AddToCalendarDialog.tsx
@@ -5,14 +5,15 @@
 
 import { Export, Globe } from '@iota/apps-ui-icons';
 import { Dialog, DialogBody, DialogContent, DialogPosition, Header } from '@iota/apps-ui-kit';
-import { normalizeIotaName } from '@iota/iota-names-sdk';
+import { GRACE_PERIOD_MS, normalizeIotaName } from '@iota/iota-names-sdk';
 
+import { RegistrationNft } from '@/lib/interfaces';
+import { isNameRecordExpired } from '@/lib/utils/names';
 import { formatDate } from '@/lib/utils/format/formatDate';
 import { buildEvent, google, ics } from '@/lib/utils/calendar';
 
 interface AddToCalendarDialogProps {
-    name: string;
-    expirationDate: Date;
+    nft: Pick<RegistrationNft, 'name' | 'expirationDate'>;
     setOpen: (bool: boolean) => void;
 }
 
@@ -52,19 +53,25 @@ function CalendarOption({ icon, title, description, onClick }: CalendarOptionPro
     );
 }
 
-export function AddToCalendarDialog({ name, expirationDate, setOpen }: AddToCalendarDialogProps) {
+export function AddToCalendarDialog({ nft, setOpen }: AddToCalendarDialogProps) {
+    const isExpired = isNameRecordExpired(nft);
+    const calendarDate = isExpired
+        ? new Date(nft.expirationDate.getTime() + GRACE_PERIOD_MS)
+        : nft.expirationDate;
+    const displayName = normalizeIotaName(nft.name);
+
     function handleClose() {
         setOpen(false);
     }
 
     function handleGoogleCalendar() {
-        const event = buildEvent(name, expirationDate);
+        const event = buildEvent(nft.name, calendarDate);
         window.open(google(event), '_blank', 'noopener noreferrer');
     }
 
     function handleDownloadIcs() {
-        const event = buildEvent(name, expirationDate);
-        downloadIcsFile(name, ics(event));
+        const event = buildEvent(nft.name, calendarDate);
+        downloadIcsFile(nft.name, ics(event));
     }
 
     return (
@@ -73,15 +80,25 @@ export function AddToCalendarDialog({ name, expirationDate, setOpen }: AddToCale
                 <Header title="Add to Calendar" onClose={handleClose} />
                 <DialogBody>
                     <div className="flex flex-col gap-md">
-                        <p className="text-body-md text-names-neutral-60">
-                            Add the expiry date of{' '}
-                            <span className="text-names-neutral-92">{normalizeIotaName(name)}</span>{' '}
-                            (
-                            <span className="text-names-neutral-92">
-                                {formatDate(expirationDate)}
-                            </span>
-                            ) to a calendar app.
-                        </p>
+                        {isExpired ? (
+                            <p className="text-body-md text-names-neutral-60">
+                                <span className="text-names-neutral-92">{displayName}</span> has
+                                already expired. Add the grace period deadline (
+                                <span className="text-names-neutral-92">
+                                    {formatDate(calendarDate)}
+                                </span>
+                                ) to your calendar — this is your last chance to renew.
+                            </p>
+                        ) : (
+                            <p className="text-body-md text-names-neutral-60">
+                                Add the expiry date of{' '}
+                                <span className="text-names-neutral-92">{displayName}</span> (
+                                <span className="text-names-neutral-92">
+                                    {formatDate(calendarDate)}
+                                </span>
+                                ) to a calendar app.
+                            </p>
+                        )}
                         <div className="flex flex-col gap-xs">
                             <CalendarOption
                                 icon={<Globe />}

--- a/apps/names/src/components/dialogs/AddToCalendarDialog.tsx
+++ b/apps/names/src/components/dialogs/AddToCalendarDialog.tsx
@@ -90,13 +90,11 @@ export function AddToCalendarDialog({ name, expirationDate, setOpen }: AddToCale
     function handleGoogleCalendar() {
         const event = buildEvent(name, expirationDate);
         window.open(google(event), '_blank', 'noopener noreferrer');
-        handleClose();
     }
 
     function handleDownloadIcs() {
         const event = buildEvent(name, expirationDate);
         downloadIcsFile(name, ics(event));
-        handleClose();
     }
 
     return (
@@ -106,25 +104,25 @@ export function AddToCalendarDialog({ name, expirationDate, setOpen }: AddToCale
                 <DialogBody>
                     <div className="flex flex-col gap-md">
                         <p className="text-body-md text-names-neutral-60">
-                            Set a reminder for{' '}
+                            Add the expiry date of{' '}
                             <span className="text-names-neutral-92">{normalizeIotaName(name)}</span>{' '}
-                            expiring on{' '}
+                            (
                             <span className="text-names-neutral-92">
                                 {formatDate(expirationDate)}
                             </span>
-                            .
+                            ) to a calendar app.
                         </p>
                         <div className="flex flex-col gap-xs">
                             <CalendarOption
                                 icon={<Globe />}
                                 title="Google Calendar"
-                                description="Opens Google Calendar to create an event. Add reminders manually after the event is created."
+                                description="Opens Google Calendar to create an event. We recommend adding reminders for 1 month and 1 day before the expiry date."
                                 onClick={handleGoogleCalendar}
                             />
                             <CalendarOption
                                 icon={<Export />}
                                 title="Download .ics"
-                                description="Downloads a calendar file compatible with any app. Includes reminders at 09:00 on the day, 1 day before, and 1 month before."
+                                description="Downloads a calendar file compatible with any app. Includes reminders at 09:00 on the expiry day, 1 day before, and 1 month before."
                                 onClick={handleDownloadIcs}
                             />
                         </div>

--- a/apps/names/src/components/dialogs/NameDialogsController.tsx
+++ b/apps/names/src/components/dialogs/NameDialogsController.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { isSubname } from '@iota/iota-names-sdk';
+import { GRACE_PERIOD_MS, isSubname } from '@iota/iota-names-sdk';
 import { Fragment } from 'react';
 
 import { RegistrationNft } from '@/lib/interfaces';
+import { isNameRecordExpired } from '@/lib/utils/names';
 
 import { DeleteNameDialog } from '.';
 import { AddToCalendarDialog } from './AddToCalendarDialog';
@@ -67,7 +68,11 @@ export function NameDialogsController({ nft, openDialogId, onClose }: NameDialog
             {openDialogId === NameDialogId.AddToCalendar ? (
                 <AddToCalendarDialog
                     name={nft.name}
-                    expirationDate={nft.expirationDate}
+                    expirationDate={
+                        isNameRecordExpired(nft)
+                            ? new Date(nft.expirationDate.getTime() + GRACE_PERIOD_MS)
+                            : nft.expirationDate
+                    }
                     setOpen={onClose}
                 />
             ) : null}

--- a/apps/names/src/components/dialogs/NameDialogsController.tsx
+++ b/apps/names/src/components/dialogs/NameDialogsController.tsx
@@ -7,6 +7,7 @@ import { Fragment } from 'react';
 import { RegistrationNft } from '@/lib/interfaces';
 
 import { DeleteNameDialog } from '.';
+import { AddToCalendarDialog } from './AddToCalendarDialog';
 import { ConnectToAddressDialog } from './ConnectToAddressDialog';
 import { CreateSubnameDialog } from './CreateSubnameDialog';
 import { EditMetadataDialog } from './EditMetadata';
@@ -61,6 +62,14 @@ export function NameDialogsController({ nft, openDialogId, onClose }: NameDialog
 
             {openDialogId === NameDialogId.EditMetadata ? (
                 <EditMetadataDialog name={nft.name} setOpen={onClose} />
+            ) : null}
+
+            {openDialogId === NameDialogId.AddToCalendar ? (
+                <AddToCalendarDialog
+                    name={nft.name}
+                    expirationDate={nft.expirationDate}
+                    setOpen={onClose}
+                />
             ) : null}
         </Fragment>
     );

--- a/apps/names/src/components/dialogs/NameDialogsController.tsx
+++ b/apps/names/src/components/dialogs/NameDialogsController.tsx
@@ -1,11 +1,10 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { GRACE_PERIOD_MS, isSubname } from '@iota/iota-names-sdk';
+import { isSubname } from '@iota/iota-names-sdk';
 import { Fragment } from 'react';
 
 import { RegistrationNft } from '@/lib/interfaces';
-import { isNameRecordExpired } from '@/lib/utils/names';
 
 import { DeleteNameDialog } from '.';
 import { AddToCalendarDialog } from './AddToCalendarDialog';
@@ -66,15 +65,7 @@ export function NameDialogsController({ nft, openDialogId, onClose }: NameDialog
             ) : null}
 
             {openDialogId === NameDialogId.AddToCalendar ? (
-                <AddToCalendarDialog
-                    name={nft.name}
-                    expirationDate={
-                        isNameRecordExpired(nft)
-                            ? new Date(nft.expirationDate.getTime() + GRACE_PERIOD_MS)
-                            : nft.expirationDate
-                    }
-                    setOpen={onClose}
-                />
+                <AddToCalendarDialog nft={nft} setOpen={onClose} />
             ) : null}
         </Fragment>
     );

--- a/apps/names/src/components/dialogs/enums.ts
+++ b/apps/names/src/components/dialogs/enums.ts
@@ -10,4 +10,5 @@ export enum NameDialogId {
     SetPermissions = 'set-permissions',
     ConnectToAddress = 'connect-to-address',
     EditMetadata = 'edit-metadata',
+    AddToCalendar = 'add-to-calendar',
 }

--- a/apps/names/src/lib/utils/calendar/buildEvent.test.ts
+++ b/apps/names/src/lib/utils/calendar/buildEvent.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { at9am, buildEvent } from './buildEvent';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+describe('at9am', () => {
+    it('sets hours to 9 and zeroes minutes, seconds, milliseconds', () => {
+        const d = new Date(2026, 2, 15, 14, 30, 45, 500);
+        const result = at9am(d);
+        expect(result.getHours()).toBe(9);
+        expect(result.getMinutes()).toBe(0);
+        expect(result.getSeconds()).toBe(0);
+        expect(result.getMilliseconds()).toBe(0);
+    });
+
+    it('does not mutate the input date', () => {
+        const d = new Date(2026, 2, 15, 14, 0, 0, 0);
+        at9am(d);
+        expect(d.getHours()).toBe(14);
+    });
+});
+
+describe('buildEvent', () => {
+    const expiration = new Date(2026, 5, 15); // June 15, 2026
+
+    it('returns 4 alerts', () => {
+        const event = buildEvent('test.iota', expiration);
+        expect(event.alerts).toHaveLength(4);
+    });
+
+    it('sets event date to the expiration date', () => {
+        const event = buildEvent('test.iota', expiration);
+        expect(event.date).toBe(expiration);
+    });
+
+    it('title includes the name', () => {
+        const event = buildEvent('test.iota', expiration);
+        expect(event.title).toContain('test');
+    });
+
+    it('description references iotanames.com', () => {
+        const event = buildEvent('test.iota', expiration);
+        expect(event.description).toContain('iotanames.com');
+    });
+
+    it('alerts are ordered from earliest to latest', () => {
+        const event = buildEvent('test.iota', expiration);
+        const times = event.alerts!.map((a) => a.triggerAt.getTime());
+        expect(times).toEqual([...times].sort((a, b) => a - b));
+    });
+
+    it('all alert triggers are at 09:00', () => {
+        const event = buildEvent('test.iota', expiration);
+        for (const alert of event.alerts!) {
+            expect(alert.triggerAt.getHours()).toBe(9);
+            expect(alert.triggerAt.getMinutes()).toBe(0);
+            expect(alert.triggerAt.getSeconds()).toBe(0);
+        }
+    });
+
+    it('one-month alert is roughly 30 days before expiration', () => {
+        const event = buildEvent('test.iota', expiration);
+        const diffDays = (expiration.getTime() - event.alerts![0].triggerAt.getTime()) / MS_PER_DAY;
+        expect(diffDays).toBeGreaterThanOrEqual(28);
+        expect(diffDays).toBeLessThanOrEqual(31);
+    });
+
+    it('one-week alert is exactly 7 days before expiration (at 9am)', () => {
+        const event = buildEvent('test.iota', expiration);
+        const expected = new Date(expiration);
+        expected.setDate(expected.getDate() - 7);
+        expected.setHours(9, 0, 0, 0);
+        expect(event.alerts![1].triggerAt.getTime()).toBe(expected.getTime());
+    });
+
+    it('one-day alert is exactly 1 day before expiration (at 9am)', () => {
+        const event = buildEvent('test.iota', expiration);
+        const expected = new Date(expiration);
+        expected.setDate(expected.getDate() - 1);
+        expected.setHours(9, 0, 0, 0);
+        expect(event.alerts![2].triggerAt.getTime()).toBe(expected.getTime());
+    });
+
+    it('expiry-day alert is on the expiration date at 9am', () => {
+        const event = buildEvent('test.iota', expiration);
+        const expected = new Date(expiration);
+        expected.setHours(9, 0, 0, 0);
+        expect(event.alerts![3].triggerAt.getTime()).toBe(expected.getTime());
+    });
+
+    it('one-month alert clamps correctly for names expiring on the 31st (Feb overflow)', () => {
+        const march31 = new Date(2026, 2, 31); // March 31
+        const event = buildEvent('test.iota', march31);
+        const oneMonthAlert = event.alerts![0].triggerAt;
+        // Should be Feb 28 at 9am (2026 is not a leap year), not March 3
+        expect(oneMonthAlert.getMonth()).toBe(1); // February
+        expect(oneMonthAlert.getDate()).toBe(28);
+    });
+});

--- a/apps/names/src/lib/utils/calendar/buildEvent.ts
+++ b/apps/names/src/lib/utils/calendar/buildEvent.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { normalizeIotaName } from '@iota/iota-names-sdk';
+
+import { formatDate } from '@/lib/utils/format/formatDate';
+
+import { subtractMonths, subtractWeeks } from './dateUtils';
+import type { CalendarEvent } from './types';
+
+export function at9am(date: Date): Date {
+    const d = new Date(date);
+    d.setHours(9, 0, 0, 0);
+    return d;
+}
+
+export function buildEvent(name: string, expirationDate: Date): CalendarEvent {
+    const displayName = normalizeIotaName(name);
+
+    const oneMonthBefore = subtractMonths(expirationDate, 1);
+    const oneWeekBefore = subtractWeeks(expirationDate, 1);
+    const oneDayBefore = new Date(expirationDate);
+    oneDayBefore.setDate(oneDayBefore.getDate() - 1);
+
+    return {
+        title: `${displayName} – Renewal Reminder`,
+        description: `Your IOTA name ${displayName} expires on ${formatDate(expirationDate)}. Remember to renew it at iotanames.com.`,
+        date: expirationDate,
+        alerts: [
+            {
+                triggerAt: at9am(oneMonthBefore),
+                description: `1 month until ${displayName} expires`,
+            },
+            { triggerAt: at9am(oneWeekBefore), description: `1 week until ${displayName} expires` },
+            { triggerAt: at9am(oneDayBefore), description: `1 day until ${displayName} expires` },
+            { triggerAt: at9am(expirationDate), description: `${displayName} expires today` },
+        ],
+    };
+}

--- a/apps/names/src/lib/utils/calendar/constants.ts
+++ b/apps/names/src/lib/utils/calendar/constants.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+export const MS_PER_DAY = 24 * 60 * 60 * 1000;

--- a/apps/names/src/lib/utils/calendar/dateUtils.test.ts
+++ b/apps/names/src/lib/utils/calendar/dateUtils.test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { subtractMonths, subtractWeeks } from './dateUtils';
+
+describe('subtractWeeks', () => {
+    it('subtracts exactly 7 days per week', () => {
+        const date = new Date(2026, 0, 15); // Jan 15
+        expect(subtractWeeks(date, 1).getDate()).toBe(8);
+        expect(subtractWeeks(date, 1).getMonth()).toBe(0);
+    });
+
+    it('rolls back across a month boundary', () => {
+        const date = new Date(2026, 1, 3); // Feb 3
+        const result = subtractWeeks(date, 1);
+        expect(result.getFullYear()).toBe(2026);
+        expect(result.getMonth()).toBe(0); // January
+        expect(result.getDate()).toBe(27);
+    });
+
+    it('rolls back across a year boundary', () => {
+        const date = new Date(2026, 0, 5); // Jan 5
+        const result = subtractWeeks(date, 1);
+        expect(result.getFullYear()).toBe(2025);
+        expect(result.getMonth()).toBe(11); // December
+        expect(result.getDate()).toBe(29);
+    });
+
+    it('does not mutate the input date', () => {
+        const date = new Date(2026, 0, 15);
+        subtractWeeks(date, 1);
+        expect(date.getDate()).toBe(15);
+    });
+
+    it('supports multiple weeks', () => {
+        const date = new Date(2026, 0, 29); // Jan 29
+        const result = subtractWeeks(date, 2);
+        expect(result.getMonth()).toBe(0);
+        expect(result.getDate()).toBe(15);
+    });
+});
+
+describe('subtractMonths', () => {
+    it('subtracts one month from a mid-month date', () => {
+        const date = new Date(2026, 2, 15); // March 15
+        const result = subtractMonths(date, 1);
+        expect(result.getFullYear()).toBe(2026);
+        expect(result.getMonth()).toBe(1); // February
+        expect(result.getDate()).toBe(15);
+    });
+
+    it('clamps to last day of month when source day overflows (31st → Feb)', () => {
+        const date = new Date(2026, 2, 31); // March 31
+        const result = subtractMonths(date, 1);
+        expect(result.getFullYear()).toBe(2026);
+        expect(result.getMonth()).toBe(1); // February
+        expect(result.getDate()).toBe(28); // 2026 is not a leap year
+    });
+
+    it('clamps to Feb 29 on a leap year', () => {
+        const date = new Date(2024, 2, 31); // March 31, 2024
+        const result = subtractMonths(date, 1);
+        expect(result.getFullYear()).toBe(2024);
+        expect(result.getMonth()).toBe(1); // February
+        expect(result.getDate()).toBe(29); // 2024 is a leap year
+    });
+
+    it('clamps to last day when subtracting from Jan 31 → Dec 31 (no overflow)', () => {
+        const date = new Date(2026, 0, 31); // Jan 31
+        const result = subtractMonths(date, 1);
+        expect(result.getFullYear()).toBe(2025);
+        expect(result.getMonth()).toBe(11); // December
+        expect(result.getDate()).toBe(31);
+    });
+
+    it('rolls back across a year boundary', () => {
+        const date = new Date(2026, 1, 15); // Feb 15
+        const result = subtractMonths(date, 2);
+        expect(result.getFullYear()).toBe(2025);
+        expect(result.getMonth()).toBe(11); // December
+        expect(result.getDate()).toBe(15);
+    });
+
+    it('does not mutate the input date', () => {
+        const date = new Date(2026, 2, 31);
+        subtractMonths(date, 1);
+        expect(date.getDate()).toBe(31);
+        expect(date.getMonth()).toBe(2);
+    });
+});

--- a/apps/names/src/lib/utils/calendar/dateUtils.ts
+++ b/apps/names/src/lib/utils/calendar/dateUtils.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+export function dateStr(d: Date): string {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${year}${month}${day}`;
+}
+
+export function subtractWeeks(date: Date, weeks: number): Date {
+    const result = new Date(date);
+    result.setDate(result.getDate() - weeks * 7);
+    return result;
+}
+
+// Clamps to the last day of the target month to avoid JS setMonth overflow
+// (e.g. March 31 - 1 month → Feb 31 → March 3 without the clamp).
+export function subtractMonths(date: Date, months: number): Date {
+    const result = new Date(date);
+    const targetDay = result.getDate();
+    result.setDate(1);
+    result.setMonth(result.getMonth() - months);
+    const lastDay = new Date(result.getFullYear(), result.getMonth() + 1, 0).getDate();
+    result.setDate(Math.min(targetDay, lastDay));
+    return result;
+}

--- a/apps/names/src/lib/utils/calendar/google.test.ts
+++ b/apps/names/src/lib/utils/calendar/google.test.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from 'vitest';

--- a/apps/names/src/lib/utils/calendar/google.test.ts
+++ b/apps/names/src/lib/utils/calendar/google.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { google } from './google';
+import type { CalendarEvent } from './types';
+
+const BASE_EVENT: CalendarEvent = {
+    title: 'My birthday party',
+    description: 'Be there!',
+    date: new Date(2025, 0, 15), // Jan 15, 2025 local time
+};
+
+function parseUrl(event: CalendarEvent) {
+    const url = new URL(google(event));
+    return { url, params: new URLSearchParams(url.search) };
+}
+
+describe('google', () => {
+    describe('URL structure', () => {
+        it('returns a Google Calendar render URL', () => {
+            const { url } = parseUrl(BASE_EVENT);
+            expect(url.origin + url.pathname).toBe('https://calendar.google.com/calendar/render');
+        });
+
+        it('sets action=TEMPLATE', () => {
+            const { params } = parseUrl(BASE_EVENT);
+            expect(params.get('action')).toBe('TEMPLATE');
+        });
+    });
+
+    describe('event fields', () => {
+        it('maps title to text param', () => {
+            const { params } = parseUrl(BASE_EVENT);
+            expect(params.get('text')).toBe('My birthday party');
+        });
+
+        it('maps description to details param', () => {
+            const { params } = parseUrl(BASE_EVENT);
+            expect(params.get('details')).toBe('Be there!');
+        });
+
+        it('formats dates as YYYYMMDD/YYYYMMDD with end date +1 day', () => {
+            const { params } = parseUrl(BASE_EVENT);
+            expect(params.get('dates')).toBe('20250115/20250116');
+        });
+    });
+
+    describe('date boundaries', () => {
+        it('rolls over at month end', () => {
+            const { params } = parseUrl({ ...BASE_EVENT, date: new Date(2025, 0, 31) });
+            expect(params.get('dates')).toBe('20250131/20250201');
+        });
+
+        it('rolls over at year end', () => {
+            const { params } = parseUrl({ ...BASE_EVENT, date: new Date(2025, 11, 31) });
+            expect(params.get('dates')).toBe('20251231/20260101');
+        });
+
+        it('handles leap day', () => {
+            const { params } = parseUrl({ ...BASE_EVENT, date: new Date(2024, 1, 29) });
+            expect(params.get('dates')).toBe('20240229/20240301');
+        });
+
+        it('pads single-digit months and days', () => {
+            const { params } = parseUrl({ ...BASE_EVENT, date: new Date(2025, 0, 5) });
+            expect(params.get('dates')).toBe('20250105/20250106');
+        });
+    });
+
+    describe('alerts', () => {
+        it('produces a valid URL even when alerts are provided', () => {
+            const event: CalendarEvent = {
+                ...BASE_EVENT,
+                alerts: [
+                    { triggerAt: new Date('2024-12-15T09:00:00Z'), description: '1 month' },
+                    { triggerAt: new Date('2025-01-14T09:00:00Z'), description: '1 day' },
+                ],
+            };
+            const { url } = parseUrl(event);
+            expect(url.href).toContain('calendar.google.com');
+        });
+
+        it('does not include alert information in the URL', () => {
+            const event: CalendarEvent = {
+                ...BASE_EVENT,
+                alerts: [{ triggerAt: new Date('2025-01-14T09:00:00Z'), description: 'reminder' }],
+            };
+            const { params } = parseUrl(event);
+            expect(params.get('reminder')).toBeNull();
+            expect(params.get('alerts')).toBeNull();
+        });
+    });
+
+    describe('special characters', () => {
+        it('handles ampersands in title', () => {
+            const { params } = parseUrl({ ...BASE_EVENT, title: 'Cats & Dogs' });
+            expect(params.get('text')).toBe('Cats & Dogs');
+        });
+
+        it('handles unicode in description', () => {
+            const { params } = parseUrl({
+                ...BASE_EVENT,
+                description: 'Renew at iotanames.com 🎉',
+            });
+            expect(params.get('details')).toBe('Renew at iotanames.com 🎉');
+        });
+    });
+});

--- a/apps/names/src/lib/utils/calendar/google.ts
+++ b/apps/names/src/lib/utils/calendar/google.ts
@@ -1,21 +1,15 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+import { MS_PER_DAY } from './constants';
 import type { CalendarEvent } from './types';
-
-function dateStr(d: Date): string {
-    const year = d.getFullYear();
-    const month = String(d.getMonth() + 1).padStart(2, '0');
-    const day = String(d.getDate()).padStart(2, '0');
-    return `${year}${month}${day}`;
-}
+import { dateStr } from './dateUtils';
 
 /**
  * Returns a Google Calendar "Add Event" URL for an all-day event.
  * Note: Google Calendar does not support reminders via URL — alerts are ignored.
  */
 export function google(event: CalendarEvent): string {
-    const MS_PER_DAY = 24 * 60 * 60 * 1000;
     const start = dateStr(event.date);
     const end = dateStr(new Date(event.date.getTime() + MS_PER_DAY));
 

--- a/apps/names/src/lib/utils/calendar/google.ts
+++ b/apps/names/src/lib/utils/calendar/google.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 import type { CalendarEvent } from './types';

--- a/apps/names/src/lib/utils/calendar/google.ts
+++ b/apps/names/src/lib/utils/calendar/google.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CalendarEvent } from './types';
+
+function dateStr(d: Date): string {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${year}${month}${day}`;
+}
+
+/**
+ * Returns a Google Calendar "Add Event" URL for an all-day event.
+ * Note: Google Calendar does not support reminders via URL — alerts are ignored.
+ */
+export function google(event: CalendarEvent): string {
+    const MS_PER_DAY = 24 * 60 * 60 * 1000;
+    const start = dateStr(event.date);
+    const end = dateStr(new Date(event.date.getTime() + MS_PER_DAY));
+
+    const params = new URLSearchParams({
+        action: 'TEMPLATE',
+        text: event.title,
+        dates: `${start}/${end}`,
+        details: event.description,
+    });
+
+    return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}

--- a/apps/names/src/lib/utils/calendar/ics.test.ts
+++ b/apps/names/src/lib/utils/calendar/ics.test.ts
@@ -1,0 +1,186 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { ics } from './ics';
+import type { CalendarEvent } from './types';
+
+const BASE_EVENT: CalendarEvent = {
+    title: 'My birthday party',
+    description: 'Be there!',
+    date: new Date(2025, 0, 15), // Jan 15, 2025 local time
+};
+
+// A fixed UTC trigger time used in tests that verify the exact TRIGGER output.
+// Using an explicit UTC string ensures tests pass in any timezone.
+const FIXED_TRIGGER = new Date('2025-01-14T09:00:00Z');
+const FIXED_TRIGGER_ICS = 'TRIGGER;VALUE=DATE-TIME:20250114T090000Z';
+
+function lines(content: string): string[] {
+    return content.split('\r\n');
+}
+
+describe('ics', () => {
+    describe('calendar structure', () => {
+        it('starts with BEGIN:VCALENDAR', () => {
+            expect(lines(ics(BASE_EVENT))[0]).toBe('BEGIN:VCALENDAR');
+        });
+
+        it('ends with END:VCALENDAR', () => {
+            const l = lines(ics(BASE_EVENT));
+            expect(l[l.length - 1]).toBe('END:VCALENDAR');
+        });
+
+        it('includes VERSION:2.0', () => {
+            expect(ics(BASE_EVENT)).toContain('VERSION:2.0');
+        });
+
+        it('includes CALSCALE:GREGORIAN', () => {
+            expect(ics(BASE_EVENT)).toContain('CALSCALE:GREGORIAN');
+        });
+
+        it('uses CRLF line endings throughout', () => {
+            const content = ics(BASE_EVENT);
+            const linesLF = content.split('\n').length;
+            const linesCRLF = content.split('\r\n').length;
+            expect(linesLF).toBe(linesCRLF);
+        });
+    });
+
+    describe('VEVENT fields', () => {
+        it('wraps event in VEVENT block', () => {
+            expect(ics(BASE_EVENT)).toContain('BEGIN:VEVENT');
+            expect(ics(BASE_EVENT)).toContain('END:VEVENT');
+        });
+
+        it('includes a UID ending in @iota-names', () => {
+            expect(ics(BASE_EVENT)).toMatch(/UID:.+@iota-names/);
+        });
+
+        it('formats DTSTART as all-day date', () => {
+            expect(ics(BASE_EVENT)).toContain('DTSTART;VALUE=DATE:20250115');
+        });
+
+        it('formats DTEND as the next day', () => {
+            expect(ics(BASE_EVENT)).toContain('DTEND;VALUE=DATE:20250116');
+        });
+
+        it('includes SUMMARY with the title', () => {
+            expect(ics(BASE_EVENT)).toContain('SUMMARY:My birthday party');
+        });
+
+        it('includes DESCRIPTION', () => {
+            expect(ics(BASE_EVENT)).toContain('DESCRIPTION:Be there!');
+        });
+    });
+
+    describe('date boundaries', () => {
+        it('rolls DTEND over at month end', () => {
+            const content = ics({ ...BASE_EVENT, date: new Date(2025, 0, 31) });
+            expect(content).toContain('DTSTART;VALUE=DATE:20250131');
+            expect(content).toContain('DTEND;VALUE=DATE:20250201');
+        });
+
+        it('rolls DTEND over at year end', () => {
+            const content = ics({ ...BASE_EVENT, date: new Date(2025, 11, 31) });
+            expect(content).toContain('DTSTART;VALUE=DATE:20251231');
+            expect(content).toContain('DTEND;VALUE=DATE:20260101');
+        });
+
+        it('handles leap day', () => {
+            const content = ics({ ...BASE_EVENT, date: new Date(2024, 1, 29) });
+            expect(content).toContain('DTSTART;VALUE=DATE:20240229');
+            expect(content).toContain('DTEND;VALUE=DATE:20240301');
+        });
+    });
+
+    describe('VALARM blocks', () => {
+        it('generates no VALARM when alerts is undefined', () => {
+            expect(ics(BASE_EVENT)).not.toContain('BEGIN:VALARM');
+        });
+
+        it('generates no VALARM when alerts is empty', () => {
+            expect(ics({ ...BASE_EVENT, alerts: [] })).not.toContain('BEGIN:VALARM');
+        });
+
+        it('generates one VALARM per alert', () => {
+            const event: CalendarEvent = {
+                ...BASE_EVENT,
+                alerts: [
+                    { triggerAt: new Date('2024-12-15T09:00:00Z'), description: '1 month away' },
+                    { triggerAt: new Date('2025-01-14T09:00:00Z'), description: '1 day away' },
+                    { triggerAt: new Date('2025-01-15T09:00:00Z'), description: 'today' },
+                ],
+            };
+            const matches = ics(event).match(/BEGIN:VALARM/g);
+            expect(matches).toHaveLength(3);
+        });
+
+        it('includes VALARM DESCRIPTION', () => {
+            const event: CalendarEvent = {
+                ...BASE_EVENT,
+                alerts: [{ triggerAt: FIXED_TRIGGER, description: 'Almost time!' }],
+            };
+            expect(ics(event)).toContain('DESCRIPTION:Almost time!');
+        });
+
+        it('uses absolute UTC datetime trigger', () => {
+            const event: CalendarEvent = {
+                ...BASE_EVENT,
+                alerts: [{ triggerAt: FIXED_TRIGGER, description: 'reminder' }],
+            };
+            expect(ics(event)).toContain(FIXED_TRIGGER_ICS);
+        });
+
+        it('preserves seconds in trigger time', () => {
+            const trigger = new Date('2025-01-14T08:30:45Z');
+            const event: CalendarEvent = {
+                ...BASE_EVENT,
+                alerts: [{ triggerAt: trigger, description: 'reminder' }],
+            };
+            expect(ics(event)).toContain('TRIGGER;VALUE=DATE-TIME:20250114T083045Z');
+        });
+
+        it('formats multiple triggers independently', () => {
+            const event: CalendarEvent = {
+                ...BASE_EVENT,
+                alerts: [
+                    { triggerAt: new Date('2024-12-15T09:00:00Z'), description: 'a' },
+                    { triggerAt: new Date('2025-01-14T09:00:00Z'), description: 'b' },
+                ],
+            };
+            const content = ics(event);
+            expect(content).toContain('TRIGGER;VALUE=DATE-TIME:20241215T090000Z');
+            expect(content).toContain('TRIGGER;VALUE=DATE-TIME:20250114T090000Z');
+        });
+    });
+
+    describe('text escaping', () => {
+        it('escapes backslashes in title', () => {
+            expect(ics({ ...BASE_EVENT, title: 'a\\b' })).toContain('SUMMARY:a\\\\b');
+        });
+
+        it('escapes semicolons in title', () => {
+            expect(ics({ ...BASE_EVENT, title: 'a;b' })).toContain('SUMMARY:a\\;b');
+        });
+
+        it('escapes commas in title', () => {
+            expect(ics({ ...BASE_EVENT, title: 'a,b' })).toContain('SUMMARY:a\\,b');
+        });
+
+        it('escapes newlines in description', () => {
+            expect(ics({ ...BASE_EVENT, description: 'line1\nline2' })).toContain(
+                'DESCRIPTION:line1\\nline2',
+            );
+        });
+
+        it('escapes special characters in alert descriptions', () => {
+            const event: CalendarEvent = {
+                ...BASE_EVENT,
+                alerts: [{ triggerAt: FIXED_TRIGGER, description: 'Renew name,iota' }],
+            };
+            expect(ics(event)).toContain('DESCRIPTION:Renew name\\,iota');
+        });
+    });
+});

--- a/apps/names/src/lib/utils/calendar/ics.test.ts
+++ b/apps/names/src/lib/utils/calendar/ics.test.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from 'vitest';

--- a/apps/names/src/lib/utils/calendar/ics.test.ts
+++ b/apps/names/src/lib/utils/calendar/ics.test.ts
@@ -73,6 +73,10 @@ describe('ics', () => {
         it('includes DESCRIPTION', () => {
             expect(ics(BASE_EVENT)).toContain('DESCRIPTION:Be there!');
         });
+
+        it('includes a DTSTAMP in UTC datetime format', () => {
+            expect(ics(BASE_EVENT)).toMatch(/DTSTAMP:\d{8}T\d{6}Z/);
+        });
     });
 
     describe('date boundaries', () => {
@@ -173,6 +177,14 @@ describe('ics', () => {
             expect(ics({ ...BASE_EVENT, description: 'line1\nline2' })).toContain(
                 'DESCRIPTION:line1\\nline2',
             );
+        });
+
+        it('escapes bare carriage returns to prevent ICS line-break injection', () => {
+            expect(ics({ ...BASE_EVENT, description: 'a\rb' })).toContain('DESCRIPTION:a\\nb');
+        });
+
+        it('escapes CRLF sequences to prevent ICS line-break injection', () => {
+            expect(ics({ ...BASE_EVENT, description: 'a\r\nb' })).toContain('DESCRIPTION:a\\nb');
         });
 
         it('escapes special characters in alert descriptions', () => {

--- a/apps/names/src/lib/utils/calendar/ics.ts
+++ b/apps/names/src/lib/utils/calendar/ics.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CalendarAlert, CalendarEvent } from './types';
+
+function escapeText(text: string): string {
+    return text
+        .replace(/\\/g, '\\\\')
+        .replace(/;/g, '\\;')
+        .replace(/,/g, '\\,')
+        .replace(/\n/g, '\\n');
+}
+
+function toAllDayDate(d: Date): string {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${year}${month}${day}`;
+}
+
+// Converts a Date to the UTC datetime string required by iCalendar: YYYYMMDDTHHmmSSZ
+function toUtcDateTime(date: Date): string {
+    return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+}
+
+function buildValarm(alert: CalendarAlert): string[] {
+    return [
+        'BEGIN:VALARM',
+        `TRIGGER;VALUE=DATE-TIME:${toUtcDateTime(alert.triggerAt)}`,
+        'ACTION:DISPLAY',
+        `DESCRIPTION:${escapeText(alert.description)}`,
+        'END:VALARM',
+    ];
+}
+
+/**
+ * Returns an iCalendar (.ics) string for an all-day event.
+ * Alerts use absolute UTC datetime triggers (TRIGGER;VALUE=DATE-TIME).
+ * Based on https://icalendar.org/
+ */
+export function ics(event: CalendarEvent): string {
+    const MS_PER_DAY = 24 * 60 * 60 * 1000;
+    const start = toAllDayDate(event.date);
+    const end = toAllDayDate(new Date(event.date.getTime() + MS_PER_DAY));
+    const uid = `${event.title.replace(/\s+/g, '-').toLowerCase()}-${start}@iota-names`;
+
+    const lines = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//IOTA Names//EN',
+        'CALSCALE:GREGORIAN',
+        'METHOD:PUBLISH',
+        'BEGIN:VEVENT',
+        `UID:${uid}`,
+        `DTSTART;VALUE=DATE:${start}`,
+        `DTEND;VALUE=DATE:${end}`,
+        `SUMMARY:${escapeText(event.title)}`,
+        `DESCRIPTION:${escapeText(event.description)}`,
+        ...(event.alerts?.flatMap(buildValarm) ?? []),
+        'END:VEVENT',
+        'END:VCALENDAR',
+    ];
+
+    return lines.join('\r\n');
+}

--- a/apps/names/src/lib/utils/calendar/ics.ts
+++ b/apps/names/src/lib/utils/calendar/ics.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 import type { CalendarAlert, CalendarEvent } from './types';

--- a/apps/names/src/lib/utils/calendar/ics.ts
+++ b/apps/names/src/lib/utils/calendar/ics.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+import { MS_PER_DAY } from './constants';
 import type { CalendarAlert, CalendarEvent } from './types';
 
 function escapeText(text: string): string {
@@ -8,6 +9,8 @@ function escapeText(text: string): string {
         .replace(/\\/g, '\\\\')
         .replace(/;/g, '\\;')
         .replace(/,/g, '\\,')
+        .replace(/\r\n/g, '\\n')
+        .replace(/\r/g, '\\n')
         .replace(/\n/g, '\\n');
 }
 
@@ -39,7 +42,6 @@ function buildValarm(alert: CalendarAlert): string[] {
  * Based on https://icalendar.org/
  */
 export function ics(event: CalendarEvent): string {
-    const MS_PER_DAY = 24 * 60 * 60 * 1000;
     const start = toAllDayDate(event.date);
     const end = toAllDayDate(new Date(event.date.getTime() + MS_PER_DAY));
     const uid = `${event.title.replace(/\s+/g, '-').toLowerCase()}-${start}@iota-names`;
@@ -52,6 +54,7 @@ export function ics(event: CalendarEvent): string {
         'METHOD:PUBLISH',
         'BEGIN:VEVENT',
         `UID:${uid}`,
+        `DTSTAMP:${toUtcDateTime(new Date())}`,
         `DTSTART;VALUE=DATE:${start}`,
         `DTEND;VALUE=DATE:${end}`,
         `SUMMARY:${escapeText(event.title)}`,

--- a/apps/names/src/lib/utils/calendar/index.ts
+++ b/apps/names/src/lib/utils/calendar/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './types';
+export { google } from './google';
+export { ics } from './ics';

--- a/apps/names/src/lib/utils/calendar/index.ts
+++ b/apps/names/src/lib/utils/calendar/index.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 export * from './types';

--- a/apps/names/src/lib/utils/calendar/index.ts
+++ b/apps/names/src/lib/utils/calendar/index.ts
@@ -4,3 +4,5 @@
 export * from './types';
 export { google } from './google';
 export { ics } from './ics';
+export { subtractMonths, subtractWeeks } from './dateUtils';
+export { at9am, buildEvent } from './buildEvent';

--- a/apps/names/src/lib/utils/calendar/types.ts
+++ b/apps/names/src/lib/utils/calendar/types.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 export interface CalendarAlert {

--- a/apps/names/src/lib/utils/calendar/types.ts
+++ b/apps/names/src/lib/utils/calendar/types.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+export interface CalendarAlert {
+    description: string;
+    triggerAt: Date;
+}
+
+export interface CalendarEvent {
+    title: string;
+    description: string;
+    date: Date;
+    alerts?: CalendarAlert[];
+}

--- a/apps/names/src/lib/utils/getNameMenuOptions.tsx
+++ b/apps/names/src/lib/utils/getNameMenuOptions.tsx
@@ -8,6 +8,7 @@ import {
     Edit,
     Info,
     Link as LinkSvg,
+    Notifications,
     Settings,
     Trade,
     Warning,
@@ -91,6 +92,12 @@ export function getNameMenuOptions(
                 !namePermissions.allowTimeExtension ||
                 isNameGracePeriodExpired,
             isDisabled: !namePermissions.allowTimeExtension,
+            hideBottomBorder: true,
+        },
+        {
+            onClick: () => onOpen(NameDialogId.AddToCalendar),
+            children: <DropdownMenuOption icon={<Notifications />} label="Add to Calendar" />,
+            isHidden: isNameGracePeriodExpired,
             hideBottomBorder: true,
         },
         {


### PR DESCRIPTION
Closes #171

# Description of change

Adds an "Add to Calendar" option to the "..." dropdown menu
  on renewable IOTA names

## How the change has been tested

Clicking it opens a panel with two options: Google Calendar (opens the web URL) and Download .ics (downloads a calendar file with automatic reminders)

- Open the ... menu on a renewable name — "Add to Calendar" appears
- Clicking "Add to Calendar" opens the panel
- "Google Calendar" opens calendar.google.com with the event pre-filled on the expiration date
- "Download .ics" downloads a .ics file; importing it into Apple Calendar / Outlook shows three reminders at 09:00: 1 month before, 1 day before, and on the day

## Screens

<img width="360" height="522" alt="image" src="https://github.com/user-attachments/assets/49400faf-2edb-4152-8f6c-9c5707bb9e1c" />
<img width="487" height="870" alt="image" src="https://github.com/user-attachments/assets/40714584-45ed-44a2-99c1-3d692119f2ca" />
<img width="1205" height="822" alt="image" src="https://github.com/user-attachments/assets/be01c4c2-327a-467c-8a50-387ba7b6a948" />
