### PR TITLE
fix(ci): Send sigkill instead of sigterm to stop the iota node

### DIFF
--- a/.github/scripts/setup-names-network.sh
+++ b/.github/scripts/setup-names-network.sh
@@ -123,7 +123,7 @@ stop_and_inject_configs() {
     echo "=== Phase 3: Stopping and injecting iota-names config ==="
 
     for pid in $PID_IOTA $PID_INDEXER_WRITER $PID_INDEXER_READER $PID_GRAPHQL; do
-        kill "$pid" 2>/dev/null || true
+        kill -9 "$pid" 2>/dev/null || true
         wait "$pid" 2>/dev/null || true
     done
 


### PR DESCRIPTION
Adapts the CI to https://github.com/iotaledger/iota/pull/11442

This fixes our CI which is now timing out e.g https://github.com/iotaledger/ts-packages/actions/runs/25718754062/job/75514657285?pr=179#step:32:286