### PR TITLE
feat(apps-backend): enable notarization feature flag on production

### DIFF
--- a/apps/apps-backend/src/features/features.controller.ts
+++ b/apps/apps-backend/src/features/features.controller.ts
@@ -224,7 +224,7 @@ export class FeaturesController {
                     defaultValue: true,
                 },
                 [Feature.ExplorerTFNotarization]: {
-                    defaultValue: false,
+                    defaultValue: true,
                 },
             },
             dateUpdated: new Date().toISOString(),


### PR DESCRIPTION
# Description of change

This PR enables the **Notarization** feature on the Explorer for the **Production** network by updating the default value of the `ExplorerTFNotarization` feature flag to `true`.

### Impact
- **Search**: Users can now search for Notarization IDs on the production explorer.
- **UI**: Trust Framework (TF) specific views and components related to notarization will become visible and active.

## Links to any relevant issues

### Readiness
The following prerequisite PRs have been merged and verified:
- #142 (Explorer search integration)
- #146 (DID search stability fix)

The Notarization client and chain services have been verified to be stable and ready for production traffic.

## How the change has been tested

- **Manual Verification**: Verified on the Dev/Staging environments with the flag enabled.
- **Code Audit**: Confirmed that the `defaultValue` change is limited strictly to the `ExplorerTFNotarization` key and doesn't affect other feature flags.
