### PR TITLE
feat(audit-trail): initialize wasm client and integrate into context

### DIFF
--- a/apps/explorer/src/components/trust-framework/trustFrameworkProvider.tsx
+++ b/apps/explorer/src/components/trust-framework/trustFrameworkProvider.tsx
@@ -6,9 +6,12 @@
 import { useIotaClient, useIotaClientContext } from '@iota/dapp-kit';
 import { type IdentityClientReadOnly } from '@iota/identity-wasm/web';
 import { type NotarizationClientReadOnly } from '@iota/notarization/web';
+// TODO: use '@iota/audit-trail/web' after publish
+import { type AuditTrailClientReadOnly } from '@iota/audit-trail';
 import { type PropsWithChildren, useEffect, useMemo, useState } from 'react';
 import { TrustFrameworkContext, type TrustFrameworkProviderContext } from '~/contexts';
 import {
+    createAuditTrailClientReadOnly,
     createIdentityClientReadOnly,
     createNotarizationClientReadOnly,
 } from '~/lib/utils/trust-framework/client';
@@ -20,6 +23,7 @@ export function TrustFrameworkProvider({ children }: PropsWithChildren) {
     const [notarizationClient, setNotarizationClient] = useState<NotarizationClientReadOnly | null>(
         null,
     );
+    const [auditTrailClient, setAuditTrailClient] = useState<AuditTrailClientReadOnly | null>(null);
 
     useEffect(() => {
         if (!iotaClient) return;
@@ -35,14 +39,21 @@ export function TrustFrameworkProvider({ children }: PropsWithChildren) {
             setNotarizationClient(_notarizationClient);
         };
         instantiateNotarizationClient();
+
+        const instantiateAuditTrailClient = async () => {
+            const _auditTrailClient = await createAuditTrailClientReadOnly(iotaClient, network);
+            setAuditTrailClient(_auditTrailClient);
+        };
+        instantiateAuditTrailClient();
     }, [iotaClient, network]);
 
     const ctx = useMemo(
         (): TrustFrameworkProviderContext => ({
             identityClient,
             notarizationClient,
+            auditTrailClient,
         }),
-        [identityClient, notarizationClient],
+        [identityClient, notarizationClient, auditTrailClient],
     );
 
     return <TrustFrameworkContext.Provider value={ctx}>{children}</TrustFrameworkContext.Provider>;

--- a/apps/explorer/src/components/trust-framework/trustFrameworkProvider.tsx
+++ b/apps/explorer/src/components/trust-framework/trustFrameworkProvider.tsx
@@ -6,8 +6,7 @@
 import { useIotaClient, useIotaClientContext } from '@iota/dapp-kit';
 import { type IdentityClientReadOnly } from '@iota/identity-wasm/web';
 import { type NotarizationClientReadOnly } from '@iota/notarization/web';
-// TODO: use '@iota/audit-trail/web' after publish
-import { type AuditTrailClientReadOnly } from '@iota/audit-trail';
+import { type AuditTrailClientReadOnly } from '@iota/audit-trails/web';
 import { type PropsWithChildren, useEffect, useMemo, useState } from 'react';
 import { TrustFrameworkContext, type TrustFrameworkProviderContext } from '~/contexts';
 import {

--- a/apps/explorer/src/contexts/trustFrameworkContext.ts
+++ b/apps/explorer/src/contexts/trustFrameworkContext.ts
@@ -5,16 +5,20 @@
 
 import type { IdentityClientReadOnly } from '@iota/identity-wasm/web';
 import type { NotarizationClientReadOnly } from '@iota/notarization/web';
+// TODO: use '@iota/audit-trail/web' after publish
+import type { AuditTrailClientReadOnly } from '@iota/audit-trail';
 import { createContext, useContext } from 'react';
 
 export interface TrustFrameworkProviderContext {
     identityClient: IdentityClientReadOnly | null;
     notarizationClient: NotarizationClientReadOnly | null;
+    auditTrailClient: AuditTrailClientReadOnly | null;
 }
 
 export const TrustFrameworkContext = createContext<TrustFrameworkProviderContext>({
     identityClient: null,
     notarizationClient: null,
+    auditTrailClient: null,
 });
 
 export function useTrustFramework(): TrustFrameworkProviderContext {
@@ -35,10 +39,18 @@ export function useNotarizationClient(): NotarizationClientReadOnly | null {
     return useTrustFramework().notarizationClient;
 }
 
+export function useAuditTrailClient(): AuditTrailClientReadOnly | null {
+    return useTrustFramework().auditTrailClient;
+}
+
 export function useIdentityPkgId(): string | null {
     return useIdentityClient()?.packageId() || null;
 }
 
 export function useNotarizationPkgId(): string | null {
     return useNotarizationClient()?.packageId() || null;
+}
+
+export function useAuditTrailPkgId(): string | null {
+    return useAuditTrailClient()?.packageId() || null;
 }

--- a/apps/explorer/src/contexts/trustFrameworkContext.ts
+++ b/apps/explorer/src/contexts/trustFrameworkContext.ts
@@ -5,8 +5,7 @@
 
 import type { IdentityClientReadOnly } from '@iota/identity-wasm/web';
 import type { NotarizationClientReadOnly } from '@iota/notarization/web';
-// TODO: use '@iota/audit-trail/web' after publish
-import type { AuditTrailClientReadOnly } from '@iota/audit-trail';
+import type { AuditTrailClientReadOnly } from '@iota/audit-trails/web';
 import { createContext, useContext } from 'react';
 
 export interface TrustFrameworkProviderContext {

--- a/apps/explorer/src/index.tsx
+++ b/apps/explorer/src/index.tsx
@@ -18,7 +18,11 @@ import './index.css';
 import { Disclaimer, handleConsentAccepted } from '@iota/core';
 import { LEGAL_LINKS } from './lib';
 import { Link } from './components';
-import { initIdentityWasmWeb, initNotarizationWasmWeb } from './lib/utils/trust-framework/client';
+import {
+    initAuditTrailWasmWeb,
+    initIdentityWasmWeb,
+    initNotarizationWasmWeb,
+} from './lib/utils/trust-framework/client';
 
 // Load Amplitude as early as we can:
 initAmplitude();
@@ -28,6 +32,9 @@ initIdentityWasmWeb();
 
 // Load Notarization WASM module as early as we can:
 initNotarizationWasmWeb();
+
+// Load Audit Trail WASM module as early as we can:
+initAuditTrailWasmWeb();
 
 // Start loading features as early as we can:
 appsBackendClient.refreshFeatures();

--- a/apps/explorer/src/lib/constants/trustFramework.constants.ts
+++ b/apps/explorer/src/lib/constants/trustFramework.constants.ts
@@ -3,5 +3,7 @@
 
 export const IOTA_IDENTITY_PKG_ID = import.meta.env.VITE_IOTA_IDENTITY_PKG_ID;
 export const IOTA_NOTARIZATION_PKG_ID = import.meta.env.VITE_IOTA_NOTARIZATION_PKG_ID;
+export const IOTA_AUDIT_TRAIL_PKG_ID = import.meta.env.VITE_IOTA_AUDIT_TRAIL_PKG_ID;
+export const IOTA_TF_COMPONENTS_PKG_ID = import.meta.env.VITE_IOTA_TF_COMPONENTS_PKG_ID;
 export const DID_PROTOCOL_SEGMENT_SYMBOL = ':';
 export const DID_URL_SEGMENT_SYMBOL = '-';

--- a/apps/explorer/src/lib/utils/trust-framework/client.ts
+++ b/apps/explorer/src/lib/utils/trust-framework/client.ts
@@ -5,8 +5,7 @@ import * as identity from '@iota/identity-wasm/web';
 import identityWasmUrl from '@iota/identity-wasm/web/identity_wasm_bg.wasm?url';
 import * as notarization from '@iota/notarization/web';
 import notarizationWasmUrl from '@iota/notarization/web/notarization_wasm_bg.wasm?url';
-// TODO: update module to `@iota/audit-trail/web when it is published
-import * as auditTrail from '@iota/audit-trail';
+import * as auditTrail from '@iota/audit-trails/web';
 import auditTrailWasmUrl from '@iota/audit-trail/audit_trail_wasm_bg.wasm?url';
 import { type IotaClient, Network } from '@iota/iota-sdk/client';
 import {

--- a/apps/explorer/src/lib/utils/trust-framework/client.ts
+++ b/apps/explorer/src/lib/utils/trust-framework/client.ts
@@ -6,7 +6,7 @@ import identityWasmUrl from '@iota/identity-wasm/web/identity_wasm_bg.wasm?url';
 import * as notarization from '@iota/notarization/web';
 import notarizationWasmUrl from '@iota/notarization/web/notarization_wasm_bg.wasm?url';
 import * as auditTrail from '@iota/audit-trails/web';
-import auditTrailWasmUrl from '@iota/audit-trail/audit_trail_wasm_bg.wasm?url';
+import auditTrailWasmUrl from '@iota/audit-trails/web/audit_trail_wasm_bg.wasm?url';
 import { type IotaClient, Network } from '@iota/iota-sdk/client';
 import {
     DID_PROTOCOL_SEGMENT_SYMBOL,

--- a/apps/explorer/src/lib/utils/trust-framework/client.ts
+++ b/apps/explorer/src/lib/utils/trust-framework/client.ts
@@ -5,17 +5,23 @@ import * as identity from '@iota/identity-wasm/web';
 import identityWasmUrl from '@iota/identity-wasm/web/identity_wasm_bg.wasm?url';
 import * as notarization from '@iota/notarization/web';
 import notarizationWasmUrl from '@iota/notarization/web/notarization_wasm_bg.wasm?url';
+// TODO: update module to `@iota/audit-trail/web when it is published
+import * as auditTrail from '@iota/audit-trail';
+import auditTrailWasmUrl from '@iota/audit-trail/audit_trail_wasm_bg.wasm?url';
 import { type IotaClient, Network } from '@iota/iota-sdk/client';
 import {
     DID_PROTOCOL_SEGMENT_SYMBOL,
     DID_URL_SEGMENT_SYMBOL,
     IOTA_IDENTITY_PKG_ID,
     IOTA_NOTARIZATION_PKG_ID,
+    IOTA_AUDIT_TRAIL_PKG_ID,
+    IOTA_TF_COMPONENTS_PKG_ID,
 } from '~/lib/constants/trustFramework.constants';
 
 const regularNetworks = new Set([Network.Mainnet, Network.Testnet, Network.Devnet]);
 let initIdentityPromise: Promise<void> | null = null;
 let initNotarizationPromise: Promise<void> | null = null;
+let initAuditTrailPromise: Promise<void> | null = null;
 
 /**
  * Idempotent initialization of WASM module of Identity.
@@ -47,6 +53,22 @@ export const initNotarizationWasmWeb = async (): Promise<void> => {
         });
     }
     return initNotarizationPromise;
+};
+
+/**
+ * Idempotent initialization of WASM module of Audit Trail.
+ *
+ * Use it everytime you need to call any audit trail API.
+ */
+export const initAuditTrailWasmWeb = async (): Promise<void> => {
+    if (!initAuditTrailPromise) {
+        initAuditTrailPromise = auditTrail.init(auditTrailWasmUrl).catch((e) => {
+            console.error('failed to load audit trail wasm (web version)', e);
+            initAuditTrailPromise = null; // allow retry
+            throw e;
+        });
+    }
+    return initAuditTrailPromise;
 };
 
 export const createIdentityClientReadOnly = async (
@@ -92,6 +114,29 @@ export const createNotarizationClientReadOnly = async (
 
     throw new Error(
         'Failed to create a NotarizationClientReadOnly; declare IOTA_NOTARIZATION_PKG_ID environment if running on a custom network.',
+    );
+};
+
+export const createAuditTrailClientReadOnly = async (
+    iotaClient: IotaClient,
+    network: string,
+): Promise<auditTrail.AuditTrailClientReadOnly> => {
+    // If IOTA_AUDIT_TRAIL_PKG_ID is declared it has precedence
+    await initAuditTrailWasmWeb();
+    if (IOTA_AUDIT_TRAIL_PKG_ID != null && IOTA_TF_COMPONENTS_PKG_ID != null) {
+        return await auditTrail.AuditTrailClientReadOnly.createWithPackageOverrides(
+            iotaClient,
+            new auditTrail.PackageOverrides(IOTA_AUDIT_TRAIL_PKG_ID, IOTA_TF_COMPONENTS_PKG_ID),
+        );
+    }
+
+    // Well-known networks have well-known notarization package id
+    if (regularNetworks.has(network as Network)) {
+        return await auditTrail.AuditTrailClientReadOnly.create(iotaClient);
+    }
+
+    throw new Error(
+        'Failed to create a AuditTrailClientReadOnly; declare IOTA_AUDIT_TRAIL_PKG_ID  and IOTA_TF_COMPONENTS_PKG_ID environment if running on a custom network.',
     );
 };
 


### PR DESCRIPTION
# Description of change

This PR integrates the `@iota/audit-trail` WASM client into the Explorer's global state. This is required to decode and verify on-chain Audit Trail objects and events in the upcoming UI views.

### Key Features and Changes
- **Client Initialization:** Added `createAuditTrailClientReadOnly` to instantiate the WASM client.
- **Context Integration:** Injected `auditTrailClient` into the `TrustFrameworkProvider` so it can be consumed globally via hooks.

## How the change has been tested
- Verified the context provider initializes without throwing errors on load.