### PR TITLE
feat(audit-trail): add search integration and data resolution hooks

### DIFF
--- a/apps/explorer/src/components/search/Search.tsx
+++ b/apps/explorer/src/components/search/Search.tsx
@@ -10,6 +10,28 @@ import { useDebouncedValue } from '~/hooks/useDebouncedValue';
 import { useSearch } from '~/hooks/useSearch';
 import { ampli } from '~/lib/utils';
 
+/**
+ * Extract an ID without a dash, if it is present as a suffix.
+ *
+ * CONTEXT: Search result `id` is used as React element key and must be unique,
+ * because of this, search result now comes with a suffix like `-notarization` or
+ * `-identity`, which must be ripped off as this is invalid network ID.
+ *
+ * @example
+ *    extractOnlyTheId('0x123-audit-trail')
+ *    // output: '0x123'
+ * @example
+ *    extractOnlyTheId('0x123-identity')
+ *    // output: '0x123'
+ * @example
+ *    extractOnlyTheId('0x123')
+ *    // output: '0x123'
+ */
+function extractOnlyTheId(possibleDashedId: string): string {
+    const dashAt = possibleDashedId.indexOf('-') || -1;
+    return dashAt > -1 ? possibleDashedId.slice(0, dashAt) : possibleDashedId;
+}
+
 export function Search(): JSX.Element {
     const [query, setQuery] = useState('');
     const debouncedQuery = useDebouncedValue(query);
@@ -22,7 +44,7 @@ export function Search(): JSX.Element {
                     searchQuery: result.id,
                     searchCategory: result.type,
                 });
-                navigate(`/${result?.type}/${encodeURIComponent(result?.id)}`, {});
+                navigate(`/${result.type}/${encodeURIComponent(extractOnlyTheId(result.id))}`, {});
                 setQuery('');
             }
         },

--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -23,7 +23,7 @@ import { useFeatureIsOn } from '@iota/apps-backend-client';
 import { type NotarizationClientReadOnly } from '@iota/notarization/web';
 import { tryDIDParse, tryEncodeDidToUrl } from '~/lib/utils/trust-framework/client';
 import { useAuditTrailClient, useIdentityClient, useNotarizationClient } from '~/contexts';
-import { type AuditTrailClientReadOnly } from '@iota/audit-trail';
+import { type AuditTrailClientReadOnly } from '@iota/audit-trails/web';
 
 const isGenesisLibAddress = (value: string): boolean => /^(0x|0X)0{0,39}[12]$/.test(value);
 

--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -22,11 +22,32 @@ import { type IdentityClientReadOnly } from '@iota/identity-wasm/web';
 import { useFeatureIsOn } from '@iota/apps-backend-client';
 import { type NotarizationClientReadOnly } from '@iota/notarization/web';
 import { tryDIDParse, tryEncodeDidToUrl } from '~/lib/utils/trust-framework/client';
-import { useIdentityClient, useNotarizationClient } from '~/contexts';
+import { useAuditTrailClient, useIdentityClient, useNotarizationClient } from '~/contexts';
+import { type AuditTrailClientReadOnly } from '@iota/audit-trail';
 
 const isGenesisLibAddress = (value: string): boolean => /^(0x|0X)0{0,39}[12]$/.test(value);
 
 type Results = { id: string; label: string; type: string }[];
+
+const getResultsForAuditTrail = async (
+    auditTrailClient: AuditTrailClientReadOnly | null,
+    isAuditTrailEnabled: boolean,
+    query: string,
+): Promise<Results | null> => {
+    if (auditTrailClient == null) return null; // client not available
+    if (!isAuditTrailEnabled) return null; // feature flag disabled
+
+    const auditTrailChain = await auditTrailClient.trail(query).get();
+    if (!auditTrailChain) return null;
+
+    return [
+        {
+            id: `${auditTrailChain.id}-audittrail`,
+            label: auditTrailChain.id,
+            type: 'audit-trail',
+        },
+    ];
+};
 
 const getResultsForNotarization = async (
     notarizationClient: NotarizationClientReadOnly | null,
@@ -41,7 +62,7 @@ const getResultsForNotarization = async (
 
     return [
         {
-            id: notarizationChain.id,
+            id: `${notarizationChain.id}-notarization`,
             label: notarizationChain.id,
             type: 'notarization',
         },
@@ -278,10 +299,12 @@ export function useSearch(query: string): UseQueryResult<Results, Error> {
     const client = useIotaClient();
     const identityClient = useIdentityClient();
     const notarizationClient = useNotarizationClient();
+    const auditTrailClient = useAuditTrailClient();
     const { data: systemStateSummary } = useIotaClientQuery('getLatestIotaSystemState');
 
     const isTFIdentityEnabled = useFeatureIsOn(Feature.ExplorerTFIdentity as string);
     const isTFNotarizationEnabled = useFeatureIsOn(Feature.ExplorerTFNotarization as string);
+    const isTFAuditTrailEnabled = useFeatureIsOn(Feature.ExplorerTFAuditTrail as string);
     const { iotaNamesClient } = useIotaNamesClient();
 
     return useQuery<Results, Error>({
@@ -296,6 +319,7 @@ export function useSearch(query: string): UseQueryResult<Results, Error> {
                     getResultsForAddress(client, query, iotaNamesClient),
                     getResultsForDid(identityClient, isTFIdentityEnabled, query),
                     getResultsForNotarization(notarizationClient, isTFNotarizationEnabled, query),
+                    getResultsForAuditTrail(auditTrailClient, isTFAuditTrailEnabled, query),
                     getResultsForObject(client, query),
                     getResultsForValidatorByPoolIdOrIotaAddress(systemStateSummary || null, query),
                 ])


### PR DESCRIPTION
# Description of change

This PR enables users to search for Audit Trail objects directly from the Explorer search bar and provides the data hooks needed to fetch their details.

### Key Features and Changes
- **Search Integration:** Updated `Search.tsx` to handle Audit Trail IDs and navigate to the correct route.
- **Data Hooks:** 
  - `useResolveAuditTrail`: Fetches the core object data.
  - `useGetEvents`: Fetches the historical event records associated with the trail.

## How the change has been tested
To test locally, paste a valid Audit Trail ID into the search bar:
1. ID: `0xa4925f5346f863e359111b96ba33002b219bfcc9386f73ee429fbb96998e25fb`
2. Verify it routes to `/audit-trail/0xa4925f5346f863e359111b96ba33002b219bfcc9386f73ee429fbb96998e25fb`.