### PR TITLE
feat(audit-trail): implement summary, records, and metadata views

### DIFF
--- a/apps/explorer/src/pages/trust-framework/audit-trail-result/AuditTrailContent.tsx
+++ b/apps/explorer/src/pages/trust-framework/audit-trail-result/AuditTrailContent.tsx
@@ -18,6 +18,11 @@ import {
     useResolveOnChainAuditTrail,
 } from '~/hooks/useResolveAuditTrail';
 import { TransactionsView } from '../common/TransactionsView';
+import { AuditTrailSummaryView } from './views/AuditTrailSummaryView';
+import { MetadataView } from './views/MetadataView';
+import { TagsView } from './views/TagsView';
+import { RecordsView } from './views/RecordsView';
+import { SideBySidePanels } from '~/components/ui/SideBySidePanels';
 
 interface AuditTrailContentProps {
     objectId: string;
@@ -107,6 +112,20 @@ export function AuditTrailContent({ objectId }: AuditTrailContentProps) {
                             .addItem(getAuditTrailType(objectResult.data!, iotaAuditTrailPackage))
                             .addItem(getAuditTrailRecordsSize(auditTrailObject))
                             .build()}
+                    />
+                    <AuditTrailSummaryView
+                        auditTrailObject={auditTrailObject}
+                        objectData={objectResult.data!}
+                    />
+                    <SideBySidePanels
+                        firstPanel={<p>Replace with LockLifecycleView</p>}
+                        secondPanel={<MetadataView auditTrail={auditTrailObject} />}
+                    />
+                    <RecordsView objectId={objectId} auditTrail={auditTrailHandle} />
+                    <SideBySidePanels
+                        ratio="66-34"
+                        firstPanel={<p>Replace with RolesView</p>}
+                        secondPanel={<TagsView tags={auditTrailObject.tags} />}
                     />
                     <TransactionsView objectId={objectId} />
                 </div>

--- a/apps/explorer/src/pages/trust-framework/audit-trail-result/views/AuditTrailSummaryView.tsx
+++ b/apps/explorer/src/pages/trust-framework/audit-trail-result/views/AuditTrailSummaryView.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { DisplayStats, TooltipPosition } from '@iota/apps-ui-kit';
+import { formatDate, useFormatCoin } from '@iota/core';
+import { type IotaObjectData } from '@iota/iota-sdk/client';
+import { CoinFormat, formatDigest } from '@iota/iota-sdk/utils';
+import clsx from 'clsx';
+import { ObjectLink, TransactionLink } from '~/components/ui';
+import { onCopySuccess } from '~/lib/utils';
+import { ErrorBoundary } from '~/components';
+// TODO: use '@iota/audit-trail/web' after published
+import { type OnChainAuditTrail } from '@iota/audit-trail';
+
+interface AuditTrailSummaryViewProps {
+    auditTrailObject: OnChainAuditTrail;
+    objectData: IotaObjectData;
+}
+
+export function AuditTrailSummaryView({
+    auditTrailObject,
+    objectData,
+}: AuditTrailSummaryViewProps): JSX.Element {
+    const objectId = objectData?.objectId;
+    const storageRebate = objectData?.storageRebate;
+    const version = `v${auditTrailObject.version}`;
+    const sequenceNumber = `${auditTrailObject.sequenceNumber}`;
+
+    const dateFormat = (timestamp: bigint): string =>
+        // Convert seconds to milliseconds for Date constructor
+        formatDate(new Date(Number(timestamp)), ['year', 'month', 'day', 'hour', 'minute']);
+    const createdAt = dateFormat(auditTrailObject.createdAt);
+    const lastTransactionBlockDigest = objectData?.previousTransaction;
+
+    return (
+        <ErrorBoundary>
+            <div className="flex flex-col gap-md">
+                <div className={clsx('address-grid-container-top', 'no-image', 'no-description')}>
+                    {objectId && (
+                        <div>
+                            <ObjectIdCard objectId={objectId} />
+                        </div>
+                    )}
+
+                    {version && (
+                        <div>
+                            <DisplayStats
+                                label="Version"
+                                value={version}
+                                tooltipPosition={TooltipPosition.Left}
+                                tooltipText="Version of object in a progressive sequence."
+                            />
+                        </div>
+                    )}
+
+                    {storageRebate && (
+                        <div>
+                            <StorageRebateCard storageRebate={storageRebate} />
+                        </div>
+                    )}
+
+                    {createdAt && (
+                        <div>
+                            <DisplayStats
+                                label="Created at"
+                                value={createdAt}
+                                tooltipPosition={TooltipPosition.Left}
+                                tooltipText="Timestamp of the transaction that first published this audit trail onchain."
+                            />
+                        </div>
+                    )}
+
+                    {sequenceNumber && (
+                        <div>
+                            <DisplayStats
+                                label="Sequence"
+                                value={sequenceNumber}
+                                tooltipPosition={TooltipPosition.Left}
+                                tooltipText="Version of state change in a progressive sequence."
+                            />
+                        </div>
+                    )}
+
+                    {lastTransactionBlockDigest && (
+                        <div>
+                            <LastTxBlockCard digest={lastTransactionBlockDigest} />
+                        </div>
+                    )}
+                </div>
+            </div>
+        </ErrorBoundary>
+    );
+}
+
+interface ObjectIdCardProps {
+    objectId: string;
+}
+
+function ObjectIdCard({ objectId }: ObjectIdCardProps): JSX.Element {
+    return (
+        <DisplayStats
+            label="Object ID"
+            value={
+                <div className="flex flex-col gap-xs">
+                    <ObjectLink objectId={objectId} copyText={objectId} />
+                </div>
+            }
+            tooltipPosition={TooltipPosition.Left}
+            tooltipText="The unique onchain identifier of the Move object storing this audit trail's state."
+        />
+    );
+}
+
+interface LastTxBlockCardProps {
+    digest: string;
+}
+
+function LastTxBlockCard({ digest }: LastTxBlockCardProps): JSX.Element {
+    return (
+        <DisplayStats
+            label="Last Transaction Block Digest"
+            value={<TransactionLink digest={digest}>{formatDigest(digest)}</TransactionLink>}
+            copyText={digest}
+            onCopySuccess={onCopySuccess}
+            tooltipPosition={TooltipPosition.Left}
+            tooltipText="Hash of the most recent transaction that modified this audit trail. Use it to inspect transaction details on the explorer."
+        />
+    );
+}
+
+interface StorageRebateCardProps {
+    storageRebate: string;
+}
+
+function StorageRebateCard({ storageRebate }: StorageRebateCardProps): JSX.Element | null {
+    const [storageRebateFormatted, symbol] = useFormatCoin({
+        balance: storageRebate,
+        format: CoinFormat.Full,
+    });
+
+    return (
+        <DisplayStats
+            label="Storage Rebate"
+            value={`-${storageRebateFormatted}`}
+            supportingLabel={symbol}
+            tooltipPosition={TooltipPosition.Left}
+            tooltipText="IOTA tokens locked as a storage deposit for this object. Partially refundable when the object is deleted or reduced in size."
+        />
+    );
+}

--- a/apps/explorer/src/pages/trust-framework/audit-trail-result/views/AuditTrailSummaryView.tsx
+++ b/apps/explorer/src/pages/trust-framework/audit-trail-result/views/AuditTrailSummaryView.tsx
@@ -9,8 +9,7 @@ import clsx from 'clsx';
 import { ObjectLink, TransactionLink } from '~/components/ui';
 import { onCopySuccess } from '~/lib/utils';
 import { ErrorBoundary } from '~/components';
-// TODO: use '@iota/audit-trail/web' after published
-import { type OnChainAuditTrail } from '@iota/audit-trail';
+import { type OnChainAuditTrail } from '@iota/audit-trails/web';
 
 interface AuditTrailSummaryViewProps {
     auditTrailObject: OnChainAuditTrail;

--- a/apps/explorer/src/pages/trust-framework/audit-trail-result/views/MetadataView.tsx
+++ b/apps/explorer/src/pages/trust-framework/audit-trail-result/views/MetadataView.tsx
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Title, TooltipPosition, Panel } from '@iota/apps-ui-kit';
-// TODO: use '@iota/audit-trail/web' after published
-import { type ImmutableMetadata, type OnChainAuditTrail } from '@iota/audit-trail';
+import { type ImmutableMetadata, type OnChainAuditTrail } from '@iota/audit-trails/web';
 import { ErrorBoundary, SyntaxHighlighter } from '~/components';
 
 interface MetadataViewProps {

--- a/apps/explorer/src/pages/trust-framework/audit-trail-result/views/MetadataView.tsx
+++ b/apps/explorer/src/pages/trust-framework/audit-trail-result/views/MetadataView.tsx
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { Title, TooltipPosition, Panel } from '@iota/apps-ui-kit';
+// TODO: use '@iota/audit-trail/web' after published
+import { type ImmutableMetadata, type OnChainAuditTrail } from '@iota/audit-trail';
+import { ErrorBoundary, SyntaxHighlighter } from '~/components';
+
+interface MetadataViewProps {
+    auditTrail: OnChainAuditTrail;
+}
+
+interface LabelledSyntaxHighlighterProps {
+    label: string;
+    code: string;
+    language: string;
+}
+
+function LabelledSyntaxHighlighter({ label, code, language }: LabelledSyntaxHighlighterProps) {
+    return (
+        <div className="flex flex-col">
+            <SyntaxHighlighter code={code} language={language} />
+            <span className="mt-1 text-body-sm text-gray-500 dark:text-gray-400">{label}</span>
+        </div>
+    );
+}
+
+export function MetadataView({ auditTrail }: MetadataViewProps) {
+    const immutableMetadata = auditTrail.immutableMetadata;
+    const updatableMetadata = auditTrail.updatableMetadata;
+
+    return (
+        <ErrorBoundary>
+            <div className="panel-bg flex w-full flex-col gap-sm--rs rounded-xl border border-transparent">
+                <UpdatableMetadataPanel metadata={updatableMetadata} />
+                <ImmutableMetadataPanel metadata={immutableMetadata} />
+            </div>
+        </ErrorBoundary>
+    );
+}
+
+function ImmutableMetadataPanel({ metadata }: { metadata?: ImmutableMetadata }) {
+    return (
+        <Panel>
+            <div className="flex w-full flex-col gap-sm">
+                <Title
+                    title="Immutable Metadata"
+                    tooltipPosition={TooltipPosition.Left}
+                    tooltipText="The immutable metadata of this Audit Trail. This data cannot be changed."
+                />
+                <div className="flex flex-col gap-y-md">
+                    <LabelledSyntaxHighlighter
+                        label="Name (Text)"
+                        code={metadata?.name ?? ''}
+                        language="text"
+                    />
+                    <LabelledSyntaxHighlighter
+                        label="Description (Text)"
+                        code={metadata?.description ?? ''}
+                        language="text"
+                    />
+                </div>
+            </div>
+        </Panel>
+    );
+}
+
+function UpdatableMetadataPanel({ metadata }: { metadata?: string }) {
+    return (
+        <Panel>
+            <div className="flex w-full flex-col gap-sm">
+                <Title
+                    title="Updatable Metadata"
+                    tooltipPosition={TooltipPosition.Left}
+                    tooltipText="The updatable metadata of this Audit Trail. This data can be changed by authorized actors."
+                />
+                <LabelledSyntaxHighlighter
+                    label="Metadata (Text)"
+                    code={metadata ?? ''}
+                    language="text"
+                />
+            </div>
+        </Panel>
+    );
+}

--- a/apps/explorer/src/pages/trust-framework/audit-trail-result/views/RecordsView.tsx
+++ b/apps/explorer/src/pages/trust-framework/audit-trail-result/views/RecordsView.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { type AuditTrailHandle, type Record, type Data } from '@iota/audit-trail';
+import { type AuditTrailHandle, type Record, type Data } from '@iota/audit-trails/web';
 import { usePaginatedAuditTrailRecords } from '~/hooks/useResolveAuditTrail';
 import {
     Panel,

--- a/apps/explorer/src/pages/trust-framework/audit-trail-result/views/RecordsView.tsx
+++ b/apps/explorer/src/pages/trust-framework/audit-trail-result/views/RecordsView.tsx
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { type AuditTrailHandle, type Record, type Data } from '@iota/audit-trail';
+import { usePaginatedAuditTrailRecords } from '~/hooks/useResolveAuditTrail';
+import {
+    Panel,
+    Title,
+    TableCellBase,
+    TableCellText,
+    Button,
+    ButtonType,
+    ButtonSize,
+} from '@iota/apps-ui-kit';
+import { TableCard, PlaceholderTable } from '~/components/ui';
+import { type ColumnDef } from '@tanstack/react-table';
+import { formatDate } from '@iota/core';
+import { useState } from 'react';
+import { formatAddress } from '@iota/iota-sdk/utils';
+
+type AuditTrailRecordsProps = {
+    objectId: string;
+    auditTrail: AuditTrailHandle;
+};
+
+const PAGE_SIZE = 15;
+
+export function RecordsView({ objectId, auditTrail }: AuditTrailRecordsProps) {
+    const { records, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+        usePaginatedAuditTrailRecords({
+            objectId,
+            auditTrail,
+            pageSize: PAGE_SIZE,
+        });
+
+    return (
+        <Panel>
+            <div className="flex w-full flex-col justify-between gap-xxs p-md--rs sm:flex-row md:items-center">
+                <Title title="Records" />
+            </div>
+            <div className="flex flex-col gap-sm p-md--rs">
+                {isLoading || isFetchingNextPage ? (
+                    <PlaceholderTable
+                        rowCount={PAGE_SIZE}
+                        rowHeight="16px"
+                        colHeadings={[
+                            'Sequence #',
+                            'Tag',
+                            'Data Preview',
+                            'Added By',
+                            'Added At',
+                            'Status',
+                        ]}
+                    />
+                ) : (
+                    <RecordsTable records={records} />
+                )}
+                {hasNextPage && (
+                    <div className="flex justify-center">
+                        <Button onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
+                            Load More
+                        </Button>
+                    </div>
+                )}
+            </div>
+        </Panel>
+    );
+}
+
+function RecordsTable({ records }: { records: Record[] }) {
+    return <TableCard data={records} columns={generateRecordsTableColumns()} />;
+}
+
+function DataPreviewCell({ data }: { data: Data }) {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const dataString = data.toString();
+
+    if (dataString.length <= 50) {
+        return (
+            <TableCellBase>
+                <TableCellText>{dataString}</TableCellText>
+            </TableCellBase>
+        );
+    }
+
+    const preview = isExpanded ? dataString : `${dataString.slice(0, 50)}...`;
+
+    return (
+        <TableCellBase>
+            <div className="group relative flex w-full flex-col">
+                <TableCellText>
+                    <div className="whitespace-pre-wrap break-all">{preview}</div>
+                </TableCellText>
+                <div className="invisible absolute inset-0 flex items-center justify-center bg-white/60 backdrop-blur-[2px] group-hover:visible dark:bg-black/60">
+                    <Button
+                        type={ButtonType.Outlined}
+                        size={ButtonSize.Small}
+                        text={isExpanded ? 'Show less' : 'Show more'}
+                        onClick={() => setIsExpanded(!isExpanded)}
+                    />
+                </div>
+            </div>
+        </TableCellBase>
+    );
+}
+
+export function generateRecordsTableColumns(): ColumnDef<Record>[] {
+    return [
+        {
+            accessorKey: 'sequenceNumber',
+            header: 'Sequence #',
+            cell: ({ getValue }) => (
+                <TableCellBase>
+                    <TableCellText>{getValue<bigint>().toString()}</TableCellText>
+                </TableCellBase>
+            ),
+        },
+        {
+            accessorKey: 'tag',
+            header: 'Tag',
+            cell: ({ getValue }) => (
+                <TableCellBase>
+                    <TableCellText>{getValue<string>() || 'N/A'}</TableCellText>
+                </TableCellBase>
+            ),
+        },
+        {
+            accessorKey: 'data',
+            header: 'Data Preview',
+            cell: ({ getValue }) => <DataPreviewCell data={getValue<Data>()} />,
+        },
+        {
+            accessorKey: 'addedBy',
+            header: 'Added By',
+            cell: ({ getValue }) => (
+                <TableCellBase>
+                    <TableCellText>{formatAddress(getValue<string>())}</TableCellText>
+                </TableCellBase>
+            ),
+        },
+        {
+            accessorKey: 'addedAt',
+            header: 'Added At',
+            cell: ({ getValue }) => (
+                <TableCellBase>
+                    <TableCellText>
+                        {formatDate(Number(getValue<bigint>()), [
+                            'year',
+                            'month',
+                            'day',
+                            'hour',
+                            'minute',
+                        ])}
+                    </TableCellText>
+                </TableCellBase>
+            ),
+        },
+        {
+            id: 'status',
+            header: 'Status',
+            cell: ({ row }) => {
+                const isReplacedBy = row.original.correction?.isReplacedBy;
+                const status =
+                    isReplacedBy !== undefined ? `Replaced by ${isReplacedBy}` : 'Active';
+                return (
+                    <TableCellBase>
+                        <TableCellText>{status}</TableCellText>
+                    </TableCellBase>
+                );
+            },
+        },
+    ];
+}

--- a/apps/explorer/src/pages/trust-framework/audit-trail-result/views/TagsView.tsx
+++ b/apps/explorer/src/pages/trust-framework/audit-trail-result/views/TagsView.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { type RecordTagEntry } from '@iota/audit-trail';
+import {
+    Panel,
+    Title,
+    KeyValueInfo,
+    ButtonUnstyled,
+    InfoBox,
+    InfoBoxType,
+    InfoBoxStyle,
+} from '@iota/apps-ui-kit';
+import { Info } from '@iota/apps-ui-icons';
+
+interface TagsCardProps {
+    tags: RecordTagEntry[];
+    onFieldsNameClick?: (tag: string) => void;
+}
+
+export function TagsView({ tags, onFieldsNameClick }: TagsCardProps) {
+    return (
+        <Panel>
+            <div className="flex flex-col gap-md p-xs">
+                <div className="flex w-full flex-col justify-between gap-xxs p-md--rs sm:flex-row md:items-center">
+                    <Title title="Tags" />
+                </div>
+                {tags.length === 0 ? (
+                    <div className="p-md--rs pt-0">
+                        <InfoBox
+                            title="No tags found"
+                            supportingText="This audit trail has no tags configured."
+                            type={InfoBoxType.Default}
+                            style={InfoBoxStyle.Elevated}
+                            icon={<Info />}
+                        />
+                    </div>
+                ) : (
+                    <div className="flex max-h-44 flex-col overflow-y-auto md:max-h-96">
+                        {tags.map(({ tag, usageCount }) => (
+                            <ButtonUnstyled
+                                key={tag}
+                                className="rounded-lg p-xs hover:bg-iota-primary-80/20"
+                                onClick={() => onFieldsNameClick && onFieldsNameClick(tag)}
+                            >
+                                <KeyValueInfo
+                                    keyText={tag}
+                                    value={usageCount.toString()}
+                                    fullwidth
+                                />
+                            </ButtonUnstyled>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </Panel>
+    );
+}

--- a/apps/explorer/src/pages/trust-framework/audit-trail-result/views/TagsView.tsx
+++ b/apps/explorer/src/pages/trust-framework/audit-trail-result/views/TagsView.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { type RecordTagEntry } from '@iota/audit-trail';
+import { type RecordTagEntry } from '@iota/audit-trails/web';
 import {
     Panel,
     Title,


### PR DESCRIPTION
# Description of change

This PR introduces the primary data views for inspecting an Audit Trail's state on the Explorer.

### Key Features and Changes
- `AuditTrailSummaryView`: Displays high-level stats (version, storage rebate, creation date).
- `RecordsView`: Renders the chronological list of events fetched from the chain.
- `MetadataView` & `TagsView`: Displays associated metadata and categorizations.

## Screenshot
<img height="1200" alt="IOTA Explorer · 4 49pm · 05-21" src="https://github.com/user-attachments/assets/d07cc8cb-6511-40c4-81a1-7d89100a2db2" />

## How the change has been tested
Navigate to `/audit-trail/0xa4925f5346f863e359111b96ba33002b219bfcc9386f73ee429fbb96998e25fb ` and verify the page wrapper loads correctly without crashing.
