### PR TITLE
fix(ci): Unify docker deploys CI environment naming

### DIFF
--- a/.github/workflows/apps_apps-backend_deploy.yml
+++ b/.github/workflows/apps_apps-backend_deploy.yml
@@ -39,9 +39,9 @@ jobs:
           fi
 
           if [ "$DEPLOY_TYPE" = "staging" ] || [ "$DEPLOY_TYPE" = "rc" ]; then
-            ENVIRONMENT="pre-production - apps-backend"
+            ENVIRONMENT="pre-production - apps"
           else
-            ENVIRONMENT="production - apps-backend"
+            ENVIRONMENT="production - apps"
           fi
 
           echo "deploy_type=$DEPLOY_TYPE" >> "$GITHUB_OUTPUT"
@@ -114,4 +114,3 @@ jobs:
         Environment: ${{ needs.resolve-deploy-type.outputs.deploy_type }}
         Image: ghcr.io/iotaledger/iota/apps-backend-${{ needs.resolve-deploy-type.outputs.deploy_type }}:${{ needs.build-and-deploy.outputs.version }}
         Workflow Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-

--- a/.github/workflows/apps_names-display_deploy.yml
+++ b/.github/workflows/apps_names-display_deploy.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    environment: production
+    environment: production - apps
     outputs:
       version: ${{ steps.commit-hash.outputs.version }}
     steps:
@@ -70,4 +70,3 @@ jobs:
         Environment: production
         Image: ghcr.io/iotaledger/iota-names/iota-names-display:${{ needs.build-and-deploy.outputs.version }}
         Workflow Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-


### PR DESCRIPTION
Fixes https://github.com/iotaledger/ts-packages/actions/runs/27629264042/job/81699439441#step:7:6

This way the names display workflow can also access the 2 secrets to deploy to the vps, also used by the apps backend.

note: I'll rename the environments in github after this PR gets merged