### PR TITLE
feat(sdk): add getRpcUrl and deprecate getFullnodeUrl. Use indexer instead of fullnode for mainnet

### DIFF
--- a/.changeset/rpc-url-fn.md
+++ b/.changeset/rpc-url-fn.md
@@ -1,0 +1,5 @@
+---
+'@iota/iota-sdk': minor
+---
+
+Add `getRpcUrl` and deprecate `getFullnodeUrl`. The network `url` is the JSON-RPC endpoint, so the new name better reflects its meaning. `getFullnodeUrl` still works as an alias.

--- a/apps/explorer/src/hooks/useEnhancedRpc.ts
+++ b/apps/explorer/src/hooks/useEnhancedRpc.ts
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 import { useIotaClient } from '@iota/dapp-kit';
-import { getFullnodeUrl, IotaClient, Network } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient, Network } from '@iota/iota-sdk/client';
 import { useMemo } from 'react';
 
 import { useNetwork } from '~/hooks';
@@ -13,7 +13,7 @@ export function useEnhancedRpcClient(): IotaClient {
     const client = useIotaClient();
     const enhancedRpc = useMemo(() => {
         if (network === Network.Localnet) {
-            return new IotaClient({ url: getFullnodeUrl(Network.Localnet) });
+            return new IotaClient({ url: getRpcUrl(Network.Localnet) });
         }
 
         return client;

--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -4,7 +4,7 @@
 
 import 'tsconfig-paths/register';
 
-import { IotaClient, getFullnodeUrl } from '@iota/iota-sdk/client';
+import { IotaClient, getRpcUrl } from '@iota/iota-sdk/client';
 import { type Keypair } from '@iota/iota-sdk/cryptography';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { Transaction } from '@iota/iota-sdk/transactions';
@@ -16,7 +16,7 @@ export async function split_coin(address: string) {
     if (!keypair) {
         throw new Error('missing keypair');
     }
-    const client = new IotaClient({ url: getFullnodeUrl('localnet') });
+    const client = new IotaClient({ url: getRpcUrl('localnet') });
 
     const coins = await client.getCoins({ owner: address });
     const coin_id = coins.data[0].coinObjectId;

--- a/dapps/kiosk/src/Root.tsx
+++ b/dapps/kiosk/src/Root.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createNetworkConfig, IotaClientProvider, WalletProvider } from '@iota/dapp-kit';
-import { getFullnodeUrl } from '@iota/iota-sdk/client';
+import { getRpcUrl } from '@iota/iota-sdk/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'react-hot-toast';
 import { Outlet } from 'react-router-dom';
@@ -14,10 +14,10 @@ import { KioskClientProvider } from './context/KioskClientContext';
 const queryClient = new QueryClient();
 
 const { networkConfig } = createNetworkConfig({
-    localnet: { url: getFullnodeUrl('localnet') },
-    devnet: { url: getFullnodeUrl('devnet') },
-    testnet: { url: getFullnodeUrl('testnet') },
-    mainnet: { url: getFullnodeUrl('mainnet') },
+    localnet: { url: getRpcUrl('localnet') },
+    devnet: { url: getRpcUrl('devnet') },
+    testnet: { url: getRpcUrl('testnet') },
+    mainnet: { url: getRpcUrl('mainnet') },
 });
 
 export default function Root() {

--- a/dapps/multisig-toolkit/src/components/preview-effects/DryRunContext.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/DryRunContext.tsx
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { createContext, ReactNode, useContext } from 'react';
 
 export type Network = 'mainnet' | 'testnet' | 'devnet' | 'localnet';
@@ -23,7 +23,7 @@ export const DryRunProvider = ({
 }) => {
     return (
         <DryRunContext.Provider
-            value={{ network, client: new IotaClient({ url: getFullnodeUrl(network) }) }}
+            value={{ network, client: new IotaClient({ url: getRpcUrl(network) }) }}
         >
             {children}
         </DryRunContext.Provider>

--- a/dapps/multisig-toolkit/src/main.tsx
+++ b/dapps/multisig-toolkit/src/main.tsx
@@ -8,7 +8,7 @@ import '@fontsource-variable/inter';
 import '@fontsource-variable/red-hat-mono';
 
 import { IotaClientProvider, WalletProvider } from '@iota/dapp-kit';
-import { getFullnodeUrl } from '@iota/iota-sdk/client';
+import { getRpcUrl } from '@iota/iota-sdk/client';
 import { QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -23,9 +23,9 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
             <IotaClientProvider
                 defaultNetwork="iota:mainnet"
                 networks={{
-                    'iota:testnet': { url: getFullnodeUrl('testnet') },
-                    'iota:mainnet': { url: getFullnodeUrl('mainnet') },
-                    'iota:devnet': { url: getFullnodeUrl('devnet') },
+                    'iota:testnet': { url: getRpcUrl('testnet') },
+                    'iota:mainnet': { url: getRpcUrl('mainnet') },
+                    'iota:devnet': { url: getRpcUrl('devnet') },
                 }}
             >
                 <WalletProvider>

--- a/dapps/multisig-toolkit/src/routes/execute-transaction.tsx
+++ b/dapps/multisig-toolkit/src/routes/execute-transaction.tsx
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { parseSerializedSignature } from '@iota/iota-sdk/cryptography';
 import { useMutation } from '@tanstack/react-query';
 import { AlertCircle } from 'lucide-react';
@@ -23,7 +23,7 @@ export default function ExecuteTransaction() {
     const [transaction, setTransaction] = useState('');
     const [signature, setSignature] = useState('');
 
-    const rpcUrl = getFullnodeUrl(network);
+    const rpcUrl = getRpcUrl(network);
     const client = new IotaClient({
         url: rpcUrl,
     });

--- a/dapps/multisig-toolkit/src/routes/offline-signer.tsx
+++ b/dapps/multisig-toolkit/src/routes/offline-signer.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCurrentAccount, useSignTransaction, useIotaClientContext } from '@iota/dapp-kit';
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Transaction } from '@iota/iota-sdk/transactions';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { AlertCircle, Terminal } from 'lucide-react';
@@ -60,7 +60,7 @@ export default function OfflineSigner() {
         mutationKey: [dryRunNetwork, 'dry-run'],
         mutationFn: async () => {
             const dryRunClient = new IotaClient({
-                url: getFullnodeUrl(dryRunNetwork),
+                url: getRpcUrl(dryRunNetwork),
             });
             const transaction = Transaction.from(bytes);
             return await dryRunClient.dryRunTransactionBlock({

--- a/dapps/sponsored-transactions/src/main.tsx
+++ b/dapps/sponsored-transactions/src/main.tsx
@@ -12,7 +12,7 @@ import { App } from './App';
 import '@iota/dapp-kit/dist/index.css';
 import './index.css';
 
-import { getFullnodeUrl } from '@iota/iota-sdk/client';
+import { getRpcUrl } from '@iota/iota-sdk/client';
 
 const queryClient = new QueryClient();
 
@@ -21,7 +21,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
         <QueryClientProvider client={queryClient}>
             <IotaClientProvider
                 defaultNetwork="testnet"
-                networks={{ testnet: { url: getFullnodeUrl('testnet') } }}
+                networks={{ testnet: { url: getRpcUrl('testnet') } }}
             >
                 <WalletProvider enableUnsafeBurner>
                     <App />

--- a/dapps/sponsored-transactions/src/utils/rpc.ts
+++ b/dapps/sponsored-transactions/src/utils/rpc.ts
@@ -2,6 +2,6 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 
-export const client = new IotaClient({ url: getFullnodeUrl('testnet') });
+export const client = new IotaClient({ url: getRpcUrl('testnet') });

--- a/sdk/.env.defaults
+++ b/sdk/.env.defaults
@@ -7,7 +7,7 @@ IOTA_NETWORKS = '
     "mainnet": {
         "id": "mainnet",
         "name": "Mainnet",
-        "url": "https://api.mainnet.iota.cafe",
+        "url": "https://indexer.mainnet.iota.cafe",
         "graphql": "https://graphql.mainnet.iota.cafe",
         "explorer": "https://explorer.rebased.iota.org",
         "chain": "iota:mainnet",

--- a/sdk/create-dapp/templates/react-client-dapp/src/networkConfig.ts
+++ b/sdk/create-dapp/templates/react-client-dapp/src/networkConfig.ts
@@ -1,15 +1,15 @@
-import { getFullnodeUrl } from '@iota/iota-sdk/client';
+import { getRpcUrl } from '@iota/iota-sdk/client';
 import { createNetworkConfig } from '@iota/dapp-kit';
 
 const { networkConfig, useNetworkVariable, useNetworkVariables } = createNetworkConfig({
     devnet: {
-        url: getFullnodeUrl('devnet'),
+        url: getRpcUrl('devnet'),
     },
     testnet: {
-        url: getFullnodeUrl('testnet'),
+        url: getRpcUrl('testnet'),
     },
     mainnet: {
-        url: getFullnodeUrl('mainnet'),
+        url: getRpcUrl('mainnet'),
     },
 });
 

--- a/sdk/create-dapp/templates/react-e2e-counter/src/networkConfig.ts
+++ b/sdk/create-dapp/templates/react-e2e-counter/src/networkConfig.ts
@@ -1,4 +1,4 @@
-import { getFullnodeUrl } from '@iota/iota-sdk/client';
+import { getRpcUrl } from '@iota/iota-sdk/client';
 import {
     DEVNET_COUNTER_PACKAGE_ID,
     TESTNET_COUNTER_PACKAGE_ID,
@@ -8,19 +8,19 @@ import { createNetworkConfig } from '@iota/dapp-kit';
 
 const { networkConfig, useNetworkVariable, useNetworkVariables } = createNetworkConfig({
     devnet: {
-        url: getFullnodeUrl('devnet'),
+        url: getRpcUrl('devnet'),
         variables: {
             counterPackageId: DEVNET_COUNTER_PACKAGE_ID,
         },
     },
     testnet: {
-        url: getFullnodeUrl('testnet'),
+        url: getRpcUrl('testnet'),
         variables: {
             counterPackageId: TESTNET_COUNTER_PACKAGE_ID,
         },
     },
     mainnet: {
-        url: getFullnodeUrl('mainnet'),
+        url: getRpcUrl('mainnet'),
         variables: {
             counterPackageId: MAINNET_COUNTER_PACKAGE_ID,
         },

--- a/sdk/dapp-kit/README.md
+++ b/sdk/dapp-kit/README.md
@@ -37,13 +37,13 @@ pages.
 
 ```tsx
 import { createNetworkConfig, IotaClientProvider, WalletProvider } from '@iota/dapp-kit';
-import { getFullnodeUrl, type IotaClientOptions } from '@iota/iota-sdk/client';
+import { getRpcUrl, type IotaClientOptions } from '@iota/iota-sdk/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Config options for the networks you want to connect to
 const { networkConfig } = createNetworkConfig({
-    localnet: { url: getFullnodeUrl('localnet') },
-    mainnet: { url: getFullnodeUrl('mainnet') },
+    localnet: { url: getRpcUrl('localnet') },
+    mainnet: { url: getRpcUrl('mainnet') },
 });
 const queryClient = new QueryClient();
 

--- a/sdk/dapp-kit/test/hooks/useIotaClient.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useIotaClient.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { renderHook } from '@testing-library/react';
 
 import { useIotaClient } from '../../src/index.js';
@@ -15,7 +15,7 @@ describe('useIotaClient', () => {
     });
 
     test('returns a IotaClient', () => {
-        const iotaClient = new IotaClient({ url: getFullnodeUrl('localnet') });
+        const iotaClient = new IotaClient({ url: getRpcUrl('localnet') });
         const wrapper = createIotaClientContextWrapper(iotaClient);
         const { result } = renderHook(() => useIotaClient(), { wrapper });
 

--- a/sdk/dapp-kit/test/hooks/useIotaClientInfiniteQuery.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useIotaClientInfiniteQuery.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { useIotaClientInfiniteQuery } from '../../src/hooks/useIotaClientInfiniteQuery.js';
@@ -9,7 +9,7 @@ import { createWalletProviderContextWrapper } from '../test-utils.js';
 
 describe('useIotaClientInfiniteQuery', () => {
     it('should fetch data', async () => {
-        const iotaClient = new IotaClient({ url: getFullnodeUrl('mainnet') });
+        const iotaClient = new IotaClient({ url: getRpcUrl('mainnet') });
         const wrapper = createWalletProviderContextWrapper({}, iotaClient);
 
         const queryTransactionBlocks = vi.spyOn(iotaClient, 'queryTransactionBlocks');

--- a/sdk/dapp-kit/test/hooks/useIotaClientMutation.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useIotaClientMutation.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { useIotaClientMutation } from '../../src/hooks/useIotaClientMutation.js';
@@ -9,7 +9,7 @@ import { createWalletProviderContextWrapper } from '../test-utils.js';
 
 describe('useIotaClientMutation', () => {
     it('should fetch data', async () => {
-        const iotaClient = new IotaClient({ url: getFullnodeUrl('mainnet') });
+        const iotaClient = new IotaClient({ url: getRpcUrl('mainnet') });
         const wrapper = createWalletProviderContextWrapper({}, iotaClient);
 
         const queryTransactionBlocks = vi.spyOn(iotaClient, 'queryTransactionBlocks');

--- a/sdk/dapp-kit/test/hooks/useIotaClientQueries.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useIotaClientQueries.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { renderHook, waitFor } from '@testing-library/react';
 
 import { useIotaClientQueries } from '../../src/hooks/useIotaClientQueries.js';
@@ -21,7 +21,7 @@ const MOCK_QUERY_TRANSACTION_BLOCK_RESULT_DATA = {
 };
 
 describe('useIotaClientQueries', () => {
-    const iotaClient = new IotaClient({ url: getFullnodeUrl('mainnet') });
+    const iotaClient = new IotaClient({ url: getRpcUrl('mainnet') });
     const wrapper = createWalletProviderContextWrapper({}, iotaClient);
     test('should fetch data', async () => {
         const getAllBalances = vi.spyOn(iotaClient, 'getAllBalances');

--- a/sdk/dapp-kit/test/hooks/useIotaClientQuery.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useIotaClientQuery.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { renderHook, waitFor } from '@testing-library/react';
 
 import { useIotaClientQuery } from '../../src/hooks/useIotaClientQuery.js';
@@ -9,7 +9,7 @@ import { createWalletProviderContextWrapper } from '../test-utils.js';
 
 describe('useIotaClientQuery', () => {
     it('should fetch data', async () => {
-        const iotaClient = new IotaClient({ url: getFullnodeUrl('mainnet') });
+        const iotaClient = new IotaClient({ url: getRpcUrl('mainnet') });
         const wrapper = createWalletProviderContextWrapper({}, iotaClient);
 
         const queryTransactionBlocks = vi.spyOn(iotaClient, 'queryTransactionBlocks');

--- a/sdk/dapp-kit/test/hooks/useSignAndExecuteTransaction.test.tsx
+++ b/sdk/dapp-kit/test/hooks/useSignAndExecuteTransaction.test.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { bcs } from '@iota/iota-sdk/bcs';
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Transaction } from '@iota/iota-sdk/transactions';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { expect, type Mock } from 'vitest';
@@ -63,7 +63,7 @@ describe('useSignAndExecuteTransaction', () => {
             features: iotaFeatures,
         });
 
-        const iotaClient = new IotaClient({ url: getFullnodeUrl('localnet') });
+        const iotaClient = new IotaClient({ url: getRpcUrl('localnet') });
         const mockSignMessageFeature = mockWallet.features['iota:signTransaction'];
         const signTransaction = mockSignMessageFeature!.signTransaction as Mock;
 
@@ -141,7 +141,7 @@ describe('useSignAndExecuteTransaction', () => {
             features: iotaFeatures,
         });
 
-        const iotaClient = new IotaClient({ url: getFullnodeUrl('localnet') });
+        const iotaClient = new IotaClient({ url: getRpcUrl('localnet') });
         const mockSignMessageFeature = mockWallet.features['iota:signTransaction'];
         const signTransaction = mockSignMessageFeature!.signTransaction as Mock;
 

--- a/sdk/dapp-kit/test/test-utils.tsx
+++ b/sdk/dapp-kit/test/test-utils.tsx
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import type { IdentifierRecord, ReadonlyWalletAccount } from '@iota/wallet-standard';
 import { getWallets } from '@iota/wallet-standard';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -21,7 +21,7 @@ export function createIotaClientContextWrapper(client: IotaClient) {
 
 export function createWalletProviderContextWrapper(
     providerProps: Omit<ComponentProps<typeof WalletProvider>, 'children'> = {},
-    iotaClient: IotaClient = new IotaClient({ url: getFullnodeUrl('localnet') }),
+    iotaClient: IotaClient = new IotaClient({ url: getRpcUrl('localnet') }),
 ) {
     const queryClient = new QueryClient();
     return function WalletProviderContextWrapper({ children }: { children: React.ReactNode }) {

--- a/sdk/examples/src/custom-signer.ts
+++ b/sdk/examples/src/custom-signer.ts
@@ -7,7 +7,7 @@ import { Signer } from '@iota/iota-sdk/cryptography';
 import type { SignatureScheme } from '@iota/iota-sdk/cryptography';
 import { Ed25519PublicKey } from '@iota/iota-sdk/keypairs/ed25519';
 import { Transaction } from '@iota/iota-sdk/transactions';
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { getFaucetHost, requestIotaFromFaucetV1 } from '@iota/iota-sdk/faucet';
 
 /**
@@ -45,7 +45,7 @@ class MyEd25519Signer extends Signer {
 }
 
 // Create a client connected to devnet
-const client = new IotaClient({ url: getFullnodeUrl('devnet') });
+const client = new IotaClient({ url: getRpcUrl('devnet') });
 
 // Generate a random 32-byte secret key (in a real app this would come from
 // your own key-management system, HSM, KMS, etc.)

--- a/sdk/examples/src/get-balance.ts
+++ b/sdk/examples/src/get-balance.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { requestIotaFromFaucetV1, getFaucetHost } from '@iota/iota-sdk/faucet';
 
@@ -14,7 +14,7 @@ import { requestIotaFromFaucetV1, getFaucetHost } from '@iota/iota-sdk/faucet';
 console.log('Setting up client and keypair...');
 
 // Create a client connected to devnet
-const client = new IotaClient({ url: getFullnodeUrl('devnet') });
+const client = new IotaClient({ url: getRpcUrl('devnet') });
 
 // Generate a new Ed25519 keypair (for demo only)
 const keypair = new Ed25519Keypair();

--- a/sdk/examples/src/move-authenticator/move-authenticator-existing.ts
+++ b/sdk/examples/src/move-authenticator/move-authenticator-existing.ts
@@ -8,7 +8,7 @@
  * already been called. Only the account object ID is needed.
  */
 
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Transaction } from '@iota/iota-sdk/transactions';
 import { bcs } from '@iota/iota-sdk/bcs';
 import { MoveAuthenticatorBuilder, MoveSigner } from '@iota/iota-sdk/keypairs/move-authenticator';
@@ -16,7 +16,7 @@ import { MoveAuthenticatorBuilder, MoveSigner } from '@iota/iota-sdk/keypairs/mo
 // Replace this with your own.
 const ACCOUNT_ID = '0xf9d1fc0438de7c776210ec6d5ebee054f1f23c8015bcfda5aa7ba71b3e3c3a13';
 
-const client = new IotaClient({ url: getFullnodeUrl('devnet') });
+const client = new IotaClient({ url: getRpcUrl('devnet') });
 
 const authBuilder = new MoveAuthenticatorBuilder(ACCOUNT_ID).addPure(
     bcs.string().serialize('hello').toBytes(),

--- a/sdk/examples/src/move-authenticator/move-authenticator.ts
+++ b/sdk/examples/src/move-authenticator/move-authenticator.ts
@@ -9,7 +9,7 @@
  * 3. Sends a transfer from the account-abstracted address.
  */
 
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { requestIotaFromFaucetV1, getFaucetHost } from '@iota/iota-sdk/faucet';
 import { Transaction } from '@iota/iota-sdk/transactions';
@@ -17,7 +17,7 @@ import { MoveAuthenticatorBuilder, MoveSigner } from '@iota/iota-sdk/keypairs/mo
 import { bcs } from '@iota/iota-sdk/bcs';
 import { execSync } from 'child_process';
 
-const client = new IotaClient({ url: getFullnodeUrl('devnet') });
+const client = new IotaClient({ url: getRpcUrl('devnet') });
 const keypair = new Ed25519Keypair();
 const deployerAddress = keypair.toIotaAddress();
 

--- a/sdk/examples/src/transfer-iota.ts
+++ b/sdk/examples/src/transfer-iota.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { Transaction } from '@iota/iota-sdk/transactions';
 import { requestIotaFromFaucetV1, getFaucetHost } from '@iota/iota-sdk/faucet';
@@ -16,7 +16,7 @@ import { requestIotaFromFaucetV1, getFaucetHost } from '@iota/iota-sdk/faucet';
 console.log('Setting up client and keypair...');
 
 // Create a client connected to devnet
-const client = new IotaClient({ url: getFullnodeUrl('devnet') });
+const client = new IotaClient({ url: getRpcUrl('devnet') });
 
 // Generate a new Ed25519 keypair (for demo only)
 const keypair = new Ed25519Keypair();

--- a/sdk/examples/src/tx-with-graphql.ts
+++ b/sdk/examples/src/tx-with-graphql.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { getGraphQLUrl } from '@iota/iota-sdk/client';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { Transaction } from '@iota/iota-sdk/transactions';
@@ -20,7 +20,7 @@ const graphqlTransport = new IotaClientGraphQLTransport({
 });
 
 // IOTA client for devnet
-const client = new IotaClient({ url: getFullnodeUrl('devnet') });
+const client = new IotaClient({ url: getRpcUrl('devnet') });
 
 // Generate a new Ed25519 keypair (for demo only)
 const keypair = new Ed25519Keypair();

--- a/sdk/graphql-transport/README.md
+++ b/sdk/graphql-transport/README.md
@@ -15,13 +15,13 @@ npm install --save @iota/graphql-transport
 
 ```ts
 import { IotaClientGraphQLTransport } from '@iota/graphql-transport';
-import { getFullnodeUrl, getGraphQLUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, getGraphQLUrl, IotaClient } from '@iota/iota-sdk/client';
 
 const client = new IotaClient({
     transport: new IotaClientGraphQLTransport({
         url: getGraphQLUrl('testnet'),
         // When specified, the transport will fallback to JSON RPC for unsupported method and parameters
-        fallbackFullNodeUrl: getFullnodeUrl('testnet'),
+        fallbackFullNodeUrl: getRpcUrl('testnet'),
     }),
 });
 ```

--- a/sdk/graphql-transport/test/compatibility.test.ts
+++ b/sdk/graphql-transport/test/compatibility.test.ts
@@ -5,7 +5,7 @@
 import { beforeAll, describe, expect, test } from 'vitest';
 
 import {
-    getFullnodeUrl,
+    getRpcUrl,
     IotaClient,
     IotaObjectData,
     IotaTransactionBlockResponse,
@@ -293,7 +293,7 @@ describe('GraphQL IotaClient compatibility', () => {
             data: [{ coinObjectId: id, version }],
         } = await toolbox.getGasObjectsOwnedByAddress();
         const fullNodeClient = new IotaClient({
-            url: getFullnodeUrl('localnet'),
+            url: getRpcUrl('localnet'),
         });
 
         const rpcObject = await fullNodeClient.tryGetPastObject({

--- a/sdk/kiosk/README.md
+++ b/sdk/kiosk/README.md
@@ -23,11 +23,11 @@ You can follow this example to create a KioskClient.
 
 ```typescript
 import { KioskClient } from '@iota/kiosk';
-import { getFullnodeUrl, IotaClient, Network } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient, Network } from '@iota/iota-sdk/client';
 
 // We need an IOTA Client. You can re-use the IotaClient of your project
 // (it's not recommended to create a new one).
-const client = new IotaClient({ url: getFullnodeUrl(Network.Testnet) });
+const client = new IotaClient({ url: getRpcUrl(Network.Testnet) });
 
 // Now we can use it to create a kiosk Client.
 const kioskClient = new KioskClient({

--- a/sdk/kiosk/test/e2e/setup.ts
+++ b/sdk/kiosk/test/e2e/setup.ts
@@ -12,7 +12,7 @@ import type {
     IotaObjectChangePublished,
     IotaTransactionBlockResponse,
 } from '@iota/iota-sdk/client';
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { getFaucetHost, requestIotaFromFaucet } from '@iota/iota-sdk/faucet';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { Transaction } from '@iota/iota-sdk/transactions';
@@ -25,7 +25,7 @@ import { KioskTransaction } from '../../src/index.js';
 //@ts-expect-error env not found on meta
 const DEFAULT_FAUCET_URL = import.meta.env.VITE_FAUCET_URL ?? getFaucetHost('localnet');
 //@ts-expect-error env not found on meta
-const DEFAULT_FULLNODE_URL = import.meta.env.VITE_FULLNODE_URL ?? getFullnodeUrl('localnet');
+const DEFAULT_FULLNODE_URL = import.meta.env.VITE_FULLNODE_URL ?? getRpcUrl('localnet');
 //@ts-expect-error env not found on meta
 const IOTA_BIN =
     import.meta.env.VITE_IOTA_BIN ??

--- a/sdk/signers/README.md
+++ b/sdk/signers/README.md
@@ -39,12 +39,12 @@ cryptographic operations.
 import Transport from '@ledgerhq/hw-transport-node-hid';
 import IotaLedgerClient from '@iota/ledgerjs-hw-app-iota';
 import { LedgerSigner } from '@iota/signers/ledger';
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Transaction } from '@iota/iota-sdk/transactions';
 
 const transport = await Transport.open(undefined);
 const ledgerClient = new IotaLedgerClient(transport);
-const iotaClient = new IotaClient({ url: getFullnodeUrl('testnet') });
+const iotaClient = new IotaClient({ url: getRpcUrl('testnet') });
 
 const signer = await LedgerSigner.fromDerivationPath(
 	"m/44'/4218'/0'/0'/0'",

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -87,10 +87,10 @@ read-only operations. The default URLs to connect with the RPC server are:
 - Devnet: `https://api.devnet.iota.cafe`
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 
 // create a client connected to devnet
-const client = new IotaClient({ url: getFullnodeUrl('devnet') });
+const client = new IotaClient({ url: getRpcUrl('devnet') });
 
 // get coins owned by an address
 await client.getCoins({
@@ -103,10 +103,10 @@ local network with a local validator, a fullnode, and a faucet server. Refer to
 [this guide](https://docs.iota.org/developer/getting-started/local-network) for more information.
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 
 // create a client connected to devnet
-const client = new IotaClient({ url: getFullnodeUrl('localnet') });
+const client = new IotaClient({ url: getRpcUrl('localnet') });
 
 // get coins owned by an address
 await client.getCoins({
@@ -117,7 +117,7 @@ await client.getCoins({
 You can also construct your own in custom connections, with the URL for your own fullnode
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 
 // create a client connected to devnet
 const client = new IotaClient({
@@ -151,14 +151,14 @@ For a primer for building transactions, refer to
 ### Transfer Object
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { Transaction } from '@iota/iota-sdk/transactions';
 
 // Generate a new Ed25519 Keypair
 const keypair = new Ed25519Keypair();
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 
 const tx = new Transaction();
@@ -178,14 +178,14 @@ console.log({ result });
 To transfer `1000` NANOS to another address:
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { Transaction } from '@iota/iota-sdk/transactions';
 
 // Generate a new Ed25519 Keypair
 const keypair = new Ed25519Keypair();
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 
 const tx = new Transaction();
@@ -201,14 +201,14 @@ console.log({ result });
 ### Merge coins
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { Transaction } from '@iota/iota-sdk/transactions';
 
 // Generate a new Ed25519 Keypair
 const keypair = new Ed25519Keypair();
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 
 const tx = new Transaction();
@@ -225,14 +225,14 @@ console.log({ result });
 ### Move Call
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { Transaction } from '@iota/iota-sdk/transactions';
 
 // Generate a new Ed25519 Keypair
 const keypair = new Ed25519Keypair();
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 const packageObjectId = '0x...';
 const tx = new Transaction();
@@ -252,7 +252,7 @@ console.log({ result });
 To publish a package:
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { Transaction } from '@iota/iota-sdk/transactions';
 
@@ -260,7 +260,7 @@ const { execSync } = require('child_process');
 // Generate a new Ed25519 Keypair
 const keypair = new Ed25519Keypair();
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 const { modules, dependencies } = JSON.parse(
     execSync(`${cliPath} move build --dump-bytecode-as-base64 --path ${packagePath}`, {
@@ -288,10 +288,10 @@ Fetch objects owned by the address
 `0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231`
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 const objects = await client.getOwnedObjects({
     owner: '0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
@@ -304,10 +304,10 @@ Fetch object details for the object with id
 `0xe19739da1a701eadc21683c5b127e62b553e833e8a15a4f292f4f48b4afea3f2`
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 const txn = await client.getObject({
     id: '0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
@@ -330,10 +330,10 @@ const txns = await client.multiGetObjects({
 Fetch transaction details from transaction digests:
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 const txn = await client.getTransaction({
     digest: '9XFneskU8tW7UxQf7tE5qFRfcN4FadtC2Z3HAZkgeETd',
@@ -398,10 +398,10 @@ Fetch coins of type `0x65b0553a591d7b13376e03a408e112c706dc0909a79080c810b93b06f
 owned by an address:
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 const coins = await client.getCoins({
     owner: '0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
@@ -412,10 +412,10 @@ const coins = await client.getCoins({
 Fetch all coin objects owned by an address:
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 const allCoins = await client.getAllCoins({
     owner: '0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
@@ -425,10 +425,10 @@ const allCoins = await client.getAllCoins({
 Fetch the total coin balance for one coin type, owned by an address:
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 // If coin type is not specified, it defaults to 0x2::iota::IOTA
 const coinBalance = await client.getBalance({
@@ -443,10 +443,10 @@ Querying events created by transactions sent by account
 `0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231`
 
 ```typescript
-import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
+import { getRpcUrl, IotaClient } from '@iota/iota-sdk/client';
 
 const client = new IotaClient({
-    url: getFullnodeUrl('testnet'),
+    url: getRpcUrl('testnet'),
 });
 const events = client.queryEvents({
     query: { Sender: "0x34abc6dfbf9ae91106ccc21b1a7839704cc9932a8ab571b7f60a2894cea219e7" },

--- a/sdk/typescript/src/client/index.ts
+++ b/sdk/typescript/src/client/index.ts
@@ -20,6 +20,7 @@ export {
     getAllNetworks,
     getNetwork,
     getDefaultNetwork,
+    getRpcUrl,
     getFullnodeUrl,
     getGraphQLUrl,
 } from './network.js';

--- a/sdk/typescript/src/client/network.ts
+++ b/sdk/typescript/src/client/network.ts
@@ -66,8 +66,16 @@ export function getDefaultNetwork(): Network {
     return (process.env.DEFAULT_NETWORK as Network) || Network.Mainnet;
 }
 
-export function getFullnodeUrl(network: NetworkId): string {
+export function getRpcUrl(network: NetworkId): string {
     return getNetwork(network).url;
+}
+
+/**
+ * @deprecated Use {@link getRpcUrl} instead. The network `url` is the JSON-RPC
+ * endpoint, not necessarily a fullnode, so the name no longer reflects its meaning.
+ */
+export function getFullnodeUrl(network: NetworkId): string {
+    return getRpcUrl(network);
 }
 
 export function getGraphQLUrl(network: NetworkId): string | undefined {

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -12,7 +12,7 @@ import { expect } from 'vitest';
 import { WebSocket } from 'ws';
 
 import type { IotaObjectChangePublished } from '../../../src/client/index.js';
-import { getFullnodeUrl, IotaClient, IotaHTTPTransport } from '../../../src/client/index.js';
+import { getRpcUrl, IotaClient, IotaHTTPTransport } from '../../../src/client/index.js';
 import type { Keypair } from '../../../src/cryptography/index.js';
 import { getFaucetHost, requestIotaFromFaucet } from '../../../src/faucet/index.js';
 import { Ed25519Keypair } from '../../../src/keypairs/ed25519/index.js';
@@ -20,7 +20,7 @@ import { Transaction, UpgradePolicy } from '../../../src/transactions/index.js';
 import { IOTA_TYPE_ARG } from '../../../src/utils/index.js';
 
 const DEFAULT_FAUCET_URL = import.meta.env.VITE_FAUCET_URL ?? getFaucetHost('localnet');
-const DEFAULT_FULLNODE_URL = import.meta.env.VITE_FULLNODE_URL ?? getFullnodeUrl('localnet');
+const DEFAULT_FULLNODE_URL = import.meta.env.VITE_FULLNODE_URL ?? getRpcUrl('localnet');
 
 const CONFIG_DATA = `
 ---


### PR DESCRIPTION
Close https://github.com/iotaledger/ts-packages/issues/227